### PR TITLE
Fix SEO & social metadata

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "joe-inz-personal-website",
-  "version": "0.0.1",
+  "version": "0.0.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "joe-inz-personal-website",
-      "version": "0.0.1",
+      "version": "0.0.3",
       "license": "MIT",
       "dependencies": {
         "@astrojs/check": "^0.9.4",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "joe-inz-personal-website",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "joe-inz-personal-website",
-      "version": "0.0.3",
+      "version": "0.0.4",
       "license": "MIT",
       "dependencies": {
         "@astrojs/check": "^0.9.4",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "joe-inz-personal-website",
   "type": "module",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "description": "A personal website built with Astro and Tailwind CSS.",
   "scripts": {
     "dev": "astro dev",

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -5,13 +5,14 @@ import Footer from './components/Footer.astro';
 import logo from "@src/assets/img/avatar.png";
 
 const GTAG_MEASUREMENT_ID = import.meta.env.PUBLIC_GTAG_MEASUREMENT_ID;
-const { title, description } = Astro.props;
+const { title, description, image, type, publishedTime, modifiedTime, tags } = Astro.props;
 ---
 
 <!doctype html>
 <html lang='en'>
 	<head>
-		<BaseHead title={title} description={description} />
+		<BaseHead title={title} description={description} image={image} type={type}
+				  publishedTime={publishedTime} modifiedTime={modifiedTime} tags={tags} />
 	</head>
 	<body class="bg-white dark:bg-zinc-900 dark:text-zinc-100 pt-16 sm:pt-0">
 		<Header/>

--- a/src/layouts/components/BaseHead.astro
+++ b/src/layouts/components/BaseHead.astro
@@ -2,7 +2,6 @@
 // Import the global.css file here so that it is included on
 // all pages through the use of the <BaseHead /> component.
 import '../../styles/global.css';
-// import Favicon from '@src/assets/img/favicon.png';
 import {FULL_NAME, SITE_DESCRIPTION, SITE_TITLE} from "../../consts";
 
 interface Props {
@@ -33,12 +32,29 @@ const canonicalURL = new URL(Astro.url.pathname, Astro.site);
 const ogImageURL = new URL(image || '/avatar.png', Astro.site).href;
 const siteName = SITE_TITLE;
 const locale = 'en_US';
+
+const structuredData = {
+    '@context': 'https://schema.org',
+    '@type': type === 'article' ? 'Article' : 'WebSite',
+    'name': title,
+    'description': description,
+    'url': canonicalURL.href,
+    'image': ogImageURL,
+    'author': {
+        '@type': 'Person',
+        'name': author,
+        'url': Astro.site?.href
+    },
+    ...(type === 'article' && publishedTime && {'datePublished': publishedTime}),
+    ...(type === 'article' && modifiedTime && {'dateModified': modifiedTime}),
+    ...(tags && {'keywords': tags.join(', ')})
+};
 ---
 
 <!-- Global Metadata -->
 <meta charset='utf-8'/>
 <meta name='viewport' content='width=device-width,initial-scale=1'/>
-<link rel='icon' href={ogImageURL}/>
+<link rel='icon' href='/favicon.png' type='image/png'/>
 <meta name='generator' content={Astro.generator}/>
 
 <!-- SEO Meta Tags -->
@@ -58,44 +74,7 @@ const locale = 'en_US';
 <meta name='description' content={description}/>
 
 <!-- Structured Data (JSON-LD) -->
-<script type='application/ld+json'>
-    {
-        JSON.stringify({
-        '@context': 'https://schema.org',
-        '@type': type
-        ===
-        'article'
-        ?
-        'Article': 'WebSite',
-        'name': title,
-        'description': description,
-        'url': canonicalURL,
-        'image': image
-        ?
-        new
-        URL(image,
-        Astro.site).href: ogImageURL,
-        'author': {
-            '@type': 'Person',
-            'name': author,
-            'url': Astro.site
-        },
-        ...(type
-        ===
-        'article'
-        &
-        &
-        publishedTime
-        &
-        & {
-        'datePublished': publishedTime
-    }),
-    ...(type === 'article' && modifiedTime && {'dateModified': modifiedTime
-    }),
-    ...(tags && {
-    'keywords': tags.join(', ')})
-    })}
-</script>
+<script is:inline type='application/ld+json' set:html={JSON.stringify(structuredData)}/>
 
 <!-- Open Graph / Facebook / LinkedIn -->
 <meta property='og:type' content={type === 'article' ? 'article' : 'website'}/>
@@ -110,7 +89,7 @@ const locale = 'en_US';
 <meta property='og:locale' content={locale}/>
 
 <!-- Twitter -->
-<meta name='twitter:card' content={ogImageURL}/>
+<meta name='twitter:card' content='summary_large_image'/>
 <meta name='twitter:url' content={Astro.url}/>
 <meta name='twitter:title' content={title}/>
 <meta name='twitter:description' content={description}/>

--- a/src/pages/[...slug].astro
+++ b/src/pages/[...slug].astro
@@ -32,7 +32,9 @@ const {
 const {Content, headings} = await render(post);
 ---
 
-<BaseLayout title={seoTitle || title} description={description} image={coverImage?.src || undefined}>
+<BaseLayout title={seoTitle || title} description={description} image={coverImage?.src || undefined}
+            type='article' publishedTime={pubDate.toISOString()}
+            modifiedTime={updatedDate?.toISOString()} tags={tags}>
     <div class='container lg:flex gap-10'>
         <main
                 class='overflow-hidden grow'


### PR DESCRIPTION
- Forward image/type/dates/tags props from BaseLayout to BaseHead so blog posts get proper OG article metadata
- Emit valid JSON-LD (pages were shipping unrendered template source)
- Fix twitter:card (summary_large_image) and use favicon.png as the favicon
- Bump version to 0.0.4