### PR TITLE
Fix dark mode persistence and theme toggle

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "joe-inz-personal-website",
-  "version": "0.0.4",
+  "version": "0.0.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "joe-inz-personal-website",
-      "version": "0.0.4",
+      "version": "0.0.5",
       "license": "MIT",
       "dependencies": {
         "@astrojs/check": "^0.9.4",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "joe-inz-personal-website",
   "type": "module",
-  "version": "0.0.4",
+  "version": "0.0.5",
   "description": "A personal website built with Astro and Tailwind CSS.",
   "scripts": {
     "dev": "astro dev",

--- a/src/layouts/components/Header.astro
+++ b/src/layouts/components/Header.astro
@@ -55,17 +55,17 @@ const menu = [
                 >
                 <a class='p-3 dark:hidden' href={LINKEDIN_ACCOUNT} target='_blank'
                 >
-                    <Image src={LinkedinBlack} width={24} height={24} alt='Github logo'/>
+                    <Image src={LinkedinBlack} width={24} height={24} alt='Linkedin logo'/>
                 </a
                 >
                 <a class='p-3 hidden dark:block' href={LINKEDIN_ACCOUNT} target='_blank'
                 >
-                    <Image src={LinkedinWhite} width={24} height={24} alt='Github logo'/>
+                    <Image src={LinkedinWhite} width={24} height={24} alt='Linkedin logo'/>
                 </a
                 >
                 <button class='p-3' id='themeToggle' aria-label='Theme mode'>
                     <svg
-                            class='sun'
+                            class='sun lucide lucide-sun'
                             xmlns='http://www.w3.org/2000/svg'
                             width='24'
                             height='24'
@@ -75,7 +75,6 @@ const menu = [
                             stroke-width='2'
                             stroke-linecap='round'
                             stroke-linejoin='round'
-                            class='lucide lucide-sun'
                     >
                         <circle cx='12' cy='12' r='4'></circle>
                         <path d='M12 2v2'></path>
@@ -91,7 +90,7 @@ const menu = [
                     </svg
                     >
                     <svg
-                            class='moon'
+                            class='moon lucide lucide-moon'
                             xmlns='http://www.w3.org/2000/svg'
                             width='24'
                             height='24'
@@ -101,7 +100,6 @@ const menu = [
                             stroke-width='2'
                             stroke-linecap='round'
                             stroke-linejoin='round'
-                            class='lucide lucide-moon'
                     >
                         <path d='M12 3a6 6 0 0 0 9 9 9 9 0 1 1-9-9Z'></path>
                     </svg
@@ -150,11 +148,11 @@ const menu = [
 
     <script is:inline>
         const theme = (() => {
-            if (window.matchMedia('(prefers-color-scheme: dark)').matches) {
-                return 'dark';
-            }
             if (typeof localStorage !== 'undefined' && localStorage.getItem('theme')) {
                 return localStorage.getItem('theme');
+            }
+            if (window.matchMedia('(prefers-color-scheme: dark)').matches) {
+                return 'dark';
             }
             return 'light';
         })();

--- a/src/pages/[...slug].astro
+++ b/src/pages/[...slug].astro
@@ -83,6 +83,7 @@ const {Content, headings} = await render(post);
                 </Prose>
                 {
                     GISCUS_REPO &&
+                    <>
                     <script
                         id='giscus-script'
                         is:inline
@@ -100,6 +101,13 @@ const {Content, headings} = await render(post);
                         data-lang='en'
                         crossorigin='anonymous'
                         async></script>
+                    <script is:inline>
+                        // Giscus reads its attributes only when the async client.js executes,
+                        // so this can still override the initial theme to match the site's.
+                        const giscusTheme = localStorage.getItem('theme') === 'dark' ? 'dark_dimmed' : 'light';
+                        document.getElementById('giscus-script')?.setAttribute('data-theme', giscusTheme);
+                    </script>
+                    </>
                 }
 
             </article>


### PR DESCRIPTION
- Check localStorage before the OS color-scheme preference, so an explicit theme choice survives reloads
- Merge the duplicated class attributes on the toggle icons; the sun/moon show/hide CSS never matched, so both icons were showing at once
- Give giscus its initial theme from the stored preference instead of preferred_color_scheme
- Fix the LinkedIn icons alt text (said 'Github logo')
- Bump version to 0.0.5