### PR TITLE
Refactor posts/tags logic, typing and TOC performance

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -53,7 +53,7 @@ All site content lives in `src/content/` as Markdown files managed by Astro's co
 - **Analytics**: Google Analytics 4 via inline gtag scripts in `BaseLayout.astro`. `PUBLIC_GTAG_MEASUREMENT_ID` is declared in the `env.schema` of `astro.config.mjs` (client/public).
 - **Comments**: Giscus integration in `[...slug].astro`, conditional on `GISCUS_*` env vars read via Vite's `loadEnv`.
 - **Site constants**: `src/consts.ts` holds name, title, tagline, social URLs.
-- **Utilities**: `src/utils.ts` has `slugify()` and `unslugify()`. A separate `src/utils/projects.ts` provides `getAllProjects()`.
+- **Utilities**: `src/utils.ts` has `slugify()`. `src/utils/posts.ts` provides `getSortedPosts()` and `getTagSlugMap()`; `src/utils/projects.ts` provides `getAllProjects()`.
 
 ### Styling
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "joe-inz-personal-website",
-  "version": "0.0.6",
+  "version": "0.0.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "joe-inz-personal-website",
-      "version": "0.0.6",
+      "version": "0.0.7",
       "license": "MIT",
       "dependencies": {
         "@astrojs/check": "^0.9.4",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "joe-inz-personal-website",
   "type": "module",
-  "version": "0.0.6",
+  "version": "0.0.7",
   "description": "A personal website built with Astro and Tailwind CSS.",
   "scripts": {
     "dev": "astro dev",

--- a/src/components/PostItem.astro
+++ b/src/components/PostItem.astro
@@ -3,8 +3,10 @@ import { slugify } from '../utils';
 import FormattedDate from './FormattedDate.astro';
 import type { CollectionEntry } from 'astro:content';
 
-type BlogPost = CollectionEntry<'blog'>;
-const { post }: Record<string, any> | { post: BlogPost } = Astro.props
+interface Props {
+  post: CollectionEntry<'blog'>;
+}
+const { post } = Astro.props;
 ---
 <div class='flex flex-col sm:flex-row gap-2 sm:items-center  border-b py-2 mb-1 capitalize dark:border-b-zinc-700'>        
   <div class='text-zinc-700 text-sm w-24 dark:text-zinc-300 shrink-0'>

--- a/src/components/PostsByYear.astro
+++ b/src/components/PostsByYear.astro
@@ -3,6 +3,9 @@ import type {CollectionEntry} from 'astro:content';
 import PostItem from './PostItem.astro';
 
 type BlogPost = CollectionEntry<'blog'>;
+interface Props {
+    posts: BlogPost[];
+}
 const {posts} = Astro.props;
 
 function groupPostsByYear(posts: BlogPost[]) {

--- a/src/components/widgets/TableOfContent.astro
+++ b/src/components/widgets/TableOfContent.astro
@@ -1,11 +1,20 @@
 ---
+import type { MarkdownHeading } from 'astro';
+
+type TocHeading = MarkdownHeading & { subheadings: TocHeading[] };
+
+interface Props {
+	headings: MarkdownHeading[];
+	maxLevel?: number;
+}
+
 const { headings, maxLevel = 3 } = Astro.props;
 const toc = buildToc(headings);
-function buildToc(headings: any) {
-	const _toc: any = [];
-	const parentHeadings = new Map();
-	(headings || []).forEach((h: any) => {
-		const heading = { ...h, subheadings: [] };
+function buildToc(headings: MarkdownHeading[]): TocHeading[] {
+	const _toc: TocHeading[] = [];
+	const parentHeadings = new Map<number, TocHeading>();
+	(headings || []).forEach((h) => {
+		const heading: TocHeading = { ...h, subheadings: [] };
 		parentHeadings.set(heading.depth, heading);
 		// Change 2 to 1 if your markdown includes your <h1>
 		if (heading.depth === 2) {
@@ -24,7 +33,7 @@ function buildToc(headings: any) {
 	<h3 class='font-extrabold uppercase mb-1 px-3 text-sm'>On This Page</h3>
 	<ul class='toc-list max-h-[calc(100vh-70px)] overflow-auto text-[.825rem] text-[var(--color-content-secondary)]'>
 		{
-			toc.map((heading: any) => (
+			toc.map((heading) => (
 				<li>
 					<a
 						class='block font-bold py-1.5 px-3 border-l border-transparent text-inherit leading-tight text-zinc-700 dark:text-zinc-300'
@@ -33,7 +42,7 @@ function buildToc(headings: any) {
 					</a>
 					{heading.subheadings?.length > 0 && (
 						<ul>
-							{heading.subheadings.map((subheading: any) => (
+							{heading.subheadings.map((subheading) => (
 								<li>
 									<a
 										class='block py-1.5 pl-6 pr-3 border-l border-transparent text-inherit leading-tight text-zinc-700 dark:text-zinc-300'

--- a/src/pages/[...slug].astro
+++ b/src/pages/[...slug].astro
@@ -121,34 +121,31 @@ const {Content, headings} = await render(post);
     </div>
 </BaseLayout>
 
-<script async is:inline>
-    const anchors = document.querySelectorAll('.prose h2[id], .prose h3[id]');
-    const links = document.querySelectorAll('nav.toc ul li a');
+<script is:inline>
+    const anchors = Array.from(document.querySelectorAll('.prose h2[id], .prose h3[id]'));
+    const links = Array.from(document.querySelectorAll('nav.toc ul li a'));
+    const activeClasses = ['bg-[var(--background-surface-color)]', 'border-[var(--soft-border-color)]', 'text-[var(--link-color)]'];
+    const inactiveClasses = ['border-transparent', 'text-inherit'];
 
-    function observeToc() {
-        if (typeof anchors != 'undefined' && anchors != null && typeof links != 'undefined' && links != null) {
-            let scrollTop = window.scrollY;
-
-            // highlight the last scrolled-to: set everything inactive first
-            for (const link of links) {
-                link.classList.add('border-transparent', 'text-inherit');
-                link.classList.remove('bg-[var(--background-surface-color)]', 'border-[var(--soft-border-color)]', 'text-[var(--link-color)]');
-            }
-            // then iterate backwards, on the first match highlight it and break
-            for (var i = anchors.length - 1; i >= 0; i--) {
-                if (scrollTop > anchors[i].offsetTop - 80) {
-                    links[i].classList.remove('border-transparent', 'text-inherit');
-                    links[i].classList.add('bg-[var(--background-surface-color)]', 'border-[var(--soft-border-color)]', 'text-[var(--link-color)]');
-                    break;
-                }
-            }
-        }
+    function highlight(activeIndex) {
+        links.forEach((link, i) => {
+            link.classList.remove(...(i === activeIndex ? inactiveClasses : activeClasses));
+            link.classList.add(...(i === activeIndex ? activeClasses : inactiveClasses));
+        });
     }
 
-    window.addEventListener('scroll', (event) => {
-        observeToc(event);
-    });
-    window.addEventListener('hashchange', (event) => {
-        observeToc(event);
-    });
+    // The observed band spans from the 80px reading line down to 25% of the
+    // viewport; a heading entering it becomes active, one leaving it downwards
+    // hands the highlight back to the previous section. No scroll listener needed.
+    const observer = new IntersectionObserver((entries) => {
+        for (const entry of entries) {
+            const index = anchors.indexOf(entry.target);
+            if (entry.isIntersecting) {
+                highlight(index);
+            } else if (entry.boundingClientRect.top > 80) {
+                highlight(index - 1);
+            }
+        }
+    }, {rootMargin: '-80px 0px -75% 0px'});
+    anchors.forEach((anchor) => observer.observe(anchor));
 </script>

--- a/src/pages/posts/index.astro
+++ b/src/pages/posts/index.astro
@@ -1,14 +1,12 @@
 ---
-import {getCollection} from 'astro:content';
-import type {CollectionEntry} from 'astro:content';
 import BaseLayout from '../../layouts/BaseLayout.astro';
 import PostsByYear from '../../components/PostsByYear.astro';
+import {getSortedPosts} from '../../utils/posts';
 
-type BlogPost = CollectionEntry<'blog'>;
 const title = "Abdellah Addoun's Blog Posts"
 const description = 'Find a set of articles, guides, tutorials, or posts about different fields and concepts in software engineering.'
 
-const posts = (await getCollection('blog')).sort((a: BlogPost, b: BlogPost) => b.data.pubDate.valueOf() - a.data.pubDate.valueOf());
+const posts = await getSortedPosts();
 ---
 
 <BaseLayout

--- a/src/pages/projects/index.astro
+++ b/src/pages/projects/index.astro
@@ -1,7 +1,7 @@
 ---
 import BaseLayout from '../../layouts/BaseLayout.astro';
 import ProjectList from '../../components/ProjectList.astro';
-import {getAllProjects} from '../../utils/projects';
+import {getAllProjects, type ProjectCollectionEntry} from '../../utils/projects';
 
 // Define hardcoded list of project IDs for sorting
 const projectOrder = [
@@ -17,10 +17,14 @@ const projectOrder = [
 
 const allProjects = await getAllProjects();
 
-// Sort projects based on the defined order
-const sortedProjects = projectOrder
-    .map(id => allProjects.find(project => project.data.id === id))
-    .filter(project => project !== undefined) as typeof allProjects;
+// Sort projects based on the defined order; anything not in the list is
+// appended at the end so a new project file can never silently disappear
+const sortedProjects = [
+    ...projectOrder
+        .map(id => allProjects.find(project => project.data.id === id))
+        .filter((project): project is ProjectCollectionEntry => project !== undefined),
+    ...allProjects.filter(project => !projectOrder.includes(project.data.id))
+];
 ---
 
 <BaseLayout

--- a/src/pages/tags/[tag]/index.astro
+++ b/src/pages/tags/[tag]/index.astro
@@ -1,28 +1,23 @@
 ---
-import type { CollectionEntry } from 'astro:content';
-import { getCollection } from 'astro:content';
 import BaseLayout from '@src/layouts/BaseLayout.astro';
-import { slugify, unslugify } from '@src/utils';
+import { slugify } from '@src/utils';
 import PostsByYear from '@src/components/PostsByYear.astro';
+import { getSortedPosts, getTagSlugMap } from '@src/utils/posts';
 
-type BlogPost = CollectionEntry<'blog'>;
 export const getStaticPaths = async () => {
-	const allPosts: BlogPost[] = await getCollection('blog');
-	return [
-		...new Set(
-			allPosts
-				.map((post) => post.data.tags)
-				.flat()
-				.filter((tag) => !!tag)
-		)
-	].map((tag) => ({ params: { tag: slugify(tag || '') } }));
+	const allPosts = await getSortedPosts();
+	return [...getTagSlugMap(allPosts).entries()].map(([slug, tagName]) => ({
+		params: { tag: slug },
+		props: { tagName }
+	}));
 };
 
 const { tag } = Astro.params;
-const allPosts: BlogPost[] = (await getCollection('blog')).sort((a, b) => b.data.pubDate.valueOf() - a.data.pubDate.valueOf());
-const taggedPosts = allPosts.filter((post) => post.data.tags?.map((tag) => slugify(tag)).includes(tag || ''));
-const title = `All Posts Tagged with ${unslugify(tag || '')}`;
-const description = `All Posts Tagged with ${unslugify(tag || '')}`;
+const { tagName } = Astro.props;
+const allPosts = await getSortedPosts();
+const taggedPosts = allPosts.filter((post) => post.data.tags?.map((t) => slugify(t)).includes(tag || ''));
+const title = `All Posts Tagged with ${tagName}`;
+const description = `All Posts Tagged with ${tagName}`;
 ---
 
 <BaseLayout

--- a/src/pages/tags/index.astro
+++ b/src/pages/tags/index.astro
@@ -69,7 +69,7 @@ const description = 'Post tags: concise keywords categorizing content for easy n
                     text-sm text-zinc-700 dark:text-zinc-300 no-underline px-3 py-1
                     transition-all duration-700
                   hover:border-zinc-700 dark:hover:border-zinc-300'
-                  href={`/tags/${slugify(tag.value)}/`}>
+                  href={`/tags/${tag.value}/`}>
                   {tag.label} ({tag.postCount})
                 </a>
               ))

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -39,4 +39,11 @@
 			background-position: 0% 50%;
 		}
 	}
+
+	@media (prefers-reduced-motion: reduce) {
+		.purple-red-gradient-wave,
+		.beige-amber-gradient-wave {
+			animation: none;
+		}
+	}
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -15,6 +15,3 @@ export const slugify = (input: string) => {
 
 	return slug;
 };
-
-export const unslugify = (slug: string) =>
-	slug.replace(/\-/g, ' ').replace(/\w\S*/g, (text) => text.charAt(0).toUpperCase() + text.slice(1).toLowerCase());

--- a/src/utils/posts.ts
+++ b/src/utils/posts.ts
@@ -1,0 +1,26 @@
+import type {CollectionEntry} from 'astro:content';
+import {getCollection} from 'astro:content';
+import {slugify} from '../utils';
+
+export type BlogPostEntry = CollectionEntry<'blog'>;
+
+export async function getSortedPosts(): Promise<BlogPostEntry[]> {
+  const posts = await getCollection('blog');
+  return posts.sort((a, b) => b.data.pubDate.valueOf() - a.data.pubDate.valueOf());
+}
+
+export function getTagSlugMap(posts: BlogPostEntry[]): Map<string, string> {
+  const tagsBySlug = new Map<string, string>();
+  for (const post of posts) {
+    for (const tag of post.data.tags ?? []) {
+      const slug = slugify(tag);
+      const existing = tagsBySlug.get(slug);
+      if (existing && existing !== tag) {
+        console.warn(`[tags] "${existing}" and "${tag}" collide on slug "${slug}"; keeping "${existing}"`);
+        continue;
+      }
+      tagsBySlug.set(slug, tag);
+    }
+  }
+  return tagsBySlug;
+}


### PR DESCRIPTION
- Extract getSortedPosts() and getTagSlugMap() into src/utils/posts.ts; posts and tag pages now share one sort/tag source instead of copy-pasted logic
- Tag pages title with the real tag name (.NET, C#) instead of a mangled de-slugified one (Net, C); slug collisions now warn at build
- Projects page appends anything missing from the hardcoded order list, so a new project file can't silently disappear
- Proper Props types for PostItem, PostsByYear and TableOfContent; drop the as-cast on the projects list; remove the now-unused unslugify()
- Replace the TOC's unthrottled scroll listener with an IntersectionObserver
- Respect prefers-reduced-motion for the gradient text animations
- Bump version to 0.0.7