### PR TITLE
Add the AMEK Consulting experience

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "joe-inz-personal-website",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "joe-inz-personal-website",
-      "version": "1.1.0",
+      "version": "1.1.1",
       "license": "MIT",
       "dependencies": {
         "@astrojs/check": "^0.9.4",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "joe-inz-personal-website",
   "type": "module",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "A personal website built with Astro and Tailwind CSS.",
   "scripts": {
     "dev": "astro dev",

--- a/src/content/experiences/09-solo-engineer.md
+++ b/src/content/experiences/09-solo-engineer.md
@@ -4,7 +4,7 @@ roleName: "Solo Engineer Looking for Opportunities"
 companyName: ""
 companyUrl: ""
 startDate: "2025-09"
-endDate: "Present"
+endDate: "2026-04"
 location: "Ain Salah - Algeria"
 workType: "remote"
 tags: [ ".NET", "Angular", "Typescript", "NestJS", "Langchain", "Langgraph", "Debugging", "Prompt Engineering", "LLM Integration", "AI Agents", "Collaboration" ]

--- a/src/content/experiences/10-amek-senior-engineer.md
+++ b/src/content/experiences/10-amek-senior-engineer.md
@@ -11,4 +11,16 @@ tags: [ ".NET", "C#", "Angular", "Typescript", "Turborepo", "Microservices", "JI
 ---
 
 In April 2026, I joined AMEK Consulting as a Senior Software Engineer, working as a consultant for JENSEN Education, a
-Swedish education provider. The full story of this chapter is still being written.
+Swedish education provider. My focus is their multi-tenant SaaS Learning Management System, preparing to launch to more
+than 30,000 users at go-live in November 2026.
+
+- Building the platform: I build backend and full-stack features for the LMS using C#, .NET, Angular, and PostgreSQL.
+- Shaping the architecture: I shape the data model and the overall solution architecture to keep services scalable and
+  maintainable as the tenant base grows.
+- Testing as a foundation: I write unit and integration tests with xUnit and Playwright, treating automated testing as
+  a foundational part of delivery.
+- Tuning performance: I tune application and Angular single-page-application performance to stay efficient under
+  growth.
+- Owning the process: I raise technical risks early in refinement sessions and help shape backlog requirements.
+- AI-assisted delivery: Using Claude Code and Cowork, I ship complete, robust user stories in days that previously took
+  one to two weeks, run two to three projects in parallel, and raise test coverage and code quality.

--- a/src/content/experiences/10-amek-senior-engineer.md
+++ b/src/content/experiences/10-amek-senior-engineer.md
@@ -1,0 +1,14 @@
+---
+id: "10-amek-senior-engineer"
+roleName: "Senior Software Engineer"
+companyName: "AMEK Consulting"
+companyUrl: "https://www.amekconsulting.se"
+startDate: "2026-04"
+endDate: "Present"
+location: "Sweden"
+workType: "remote"
+tags: [ ".NET", "C#", "Angular", "Typescript", "Turborepo", "Microservices", "JIRA", "Bitbucket", "Jenkins", "Google Workspace", "SAML", "Claude" ]
+---
+
+In April 2026, I joined AMEK Consulting as a Senior Software Engineer, working as a consultant for JENSEN Education, a
+Swedish education provider. The full story of this chapter is still being written.

--- a/src/content/experiences/10-amek-senior-engineer.md
+++ b/src/content/experiences/10-amek-senior-engineer.md
@@ -7,20 +7,21 @@ startDate: "2026-04"
 endDate: "Present"
 location: "Sweden"
 workType: "remote"
-tags: [ ".NET", "C#", "Angular", "Typescript", "Turborepo", "Microservices", "JIRA", "Bitbucket", "Jenkins", "Google Workspace", "SAML", "Claude" ]
+tags: [ ".NET", "C#", "Angular", "Typescript", "PostgreSQL", "Playwright", "Turborepo", "Microservices", "JIRA", "Bitbucket", "Jenkins", "Google Workspace", "SAML", "Claude" ]
 ---
 
 In April 2026, I joined AMEK Consulting as a Senior Software Engineer, working as a consultant for JENSEN Education, a
-Swedish education provider. My focus is their multi-tenant SaaS Learning Management System, preparing to launch to more
-than 30,000 users at go-live in November 2026.
+Swedish education provider. I build backend and full-stack features for their multi-tenant SaaS Learning Management
+System, a platform preparing to launch to more than 30,000 users at go-live in November 2026, built with C#, .NET,
+Angular, and PostgreSQL.
 
-- Building the platform: I build backend and full-stack features for the LMS using C#, .NET, Angular, and PostgreSQL.
-- Shaping the architecture: I shape the data model and the overall solution architecture to keep services scalable and
-  maintainable as the tenant base grows.
-- Testing as a foundation: I write unit and integration tests with xUnit and Playwright, treating automated testing as
-  a foundational part of delivery.
-- Tuning performance: I tune application and Angular single-page-application performance to stay efficient under
-  growth.
-- Owning the process: I raise technical risks early in refinement sessions and help shape backlog requirements.
-- AI-assisted delivery: Using Claude Code and Cowork, I ship complete, robust user stories in days that previously took
-  one to two weeks, run two to three projects in parallel, and raise test coverage and code quality.
+Beyond feature work, I help shape the data model and the overall solution architecture so the services stay scalable
+and maintainable as the tenant base grows. I treat automated testing as a foundational part of delivery, writing unit
+and integration tests with xUnit and Playwright, and I tune both application and Angular single-page-application
+performance to keep the platform efficient under growth.
+
+I also make a point of raising technical risks early in refinement sessions and helping shape backlog requirements,
+so problems get solved on the whiteboard before they reach production. By bringing AI-assisted development into my
+daily workflow with tools like Claude Code and Cowork, I now ship complete, robust user stories in days instead of the
+one to two weeks they used to take, run two to three projects in parallel, and raise test coverage and code quality
+along the way. This chapter is still being written, and it is already reshaping how I think about building software.

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -71,7 +71,7 @@ const RECOMMENDATIONS_URL = `${LINKEDIN_ACCOUNT}/details/recommendations/`;
                 </h2>
                 <p class='text-base text-muted leading-relaxed mb-7'>
                     From a first backend job in Dubai to leading teams and managing development for US startups, to
-                    building solo today. The full story, with the lessons attached, lives on the About page.
+                    consulting for Swedish clients today. The full story, with the lessons attached, lives on the About page.
                 </p>
                 <a href='/about/' class='btn btn-secondary arrow-link !text-strong'>Read the full story <span class='arrow'>→</span></a>
             </div>


### PR DESCRIPTION
- Add the AMEK Consulting entry: senior software engineer consulting for JENSEN Education since April 2026
- Close the solo chapter at April 2026, so the timeline has a single current role
- Update the home teaser line to match
- Bump version to 1.1.1