### PR TITLE
Reading direction on the about timeline

### DIFF
--- a/docs/superpowers/plans/2026-07-16-about-timeline-reading-direction.md
+++ b/docs/superpowers/plans/2026-07-16-about-timeline-reading-direction.md
@@ -406,14 +406,20 @@ Change its bottom margin from `mb-12` to `mb-6` and insert the control after it,
             <h2 class='font-display text-4xl md:text-[44px] font-semibold text-strong leading-tight mb-6'>
                 The story behind my experience.
             </h2>
-            <div class='flex items-center gap-2 mb-12' id='orderControl'>
-                <span class='kicker'>Read</span>
+            <div class='flex items-center gap-2 mb-12' id='orderControl' role='group' aria-labelledby='orderControlLabel'>
+                <span class='kicker' id='orderControlLabel'>Read</span>
                 <button type='button' class='order-btn chip' data-order='latest' aria-pressed='true'>Latest first</button>
                 <button type='button' class='order-btn chip' data-order='story' aria-pressed='false'>Story order</button>
             </div>
 ```
 
 `.chip` is an existing shared class from `src/styles/global.css`.
+
+**Why `role='group'` + `aria-pressed`, and not a radiogroup:** two `aria-pressed` buttons on their own establish no relationship, so a screen reader announces them as unrelated toggles rather than a 1-of-2 choice, and the visible "Read" label is not programmatically associated with either. `role='group'` + `aria-labelledby` fixes both. The stricter pattern — `role='radiogroup'` + `role='radio'` + `aria-checked` — was considered and rejected: `role='radio'` promises arrow-key navigation between options, and Task 6 wires these with a plain click listener. Announcing a keyboard contract we do not honour is worse than the lighter pattern. Keeping `aria-pressed` also keeps Task 6's script and this task's `[aria-pressed='true']` CSS selector unchanged.
+
+**Known, accepted limitations** (raised in review, deliberately not fixed here):
+- The pressed and unpressed backgrounds differ by only ~1.39:1 contrast. Acceptable because `font-weight: 600` plus the `text-muted` → `text-strong` swap give a second, high-contrast channel (10.8:1 light, 7.6:1 dark), so the state is not signalled by colour alone.
+- `.order-btn` inherits the browser default focus ring. No interactive class in `global.css` defines a focus style, so this is consistent with the codebase rather than a regression. A project-wide focus style is a separate task.
 
 - [ ] **Step 2: Style the selected state**
 

--- a/docs/superpowers/plans/2026-07-16-about-timeline-reading-direction.md
+++ b/docs/superpowers/plans/2026-07-16-about-timeline-reading-direction.md
@@ -274,12 +274,23 @@ In `src/pages/about.astro`, inside the same `<style is:global>` block, add this 
 `.order-story .cue-forward` rule from Task 2:
 
 ```css
-    /* The leading card has nothing before it — true in either order, so :first-child
-       handles both without position logic. */
-    .timeline-entry:first-child .direction-cue {
+    /* The leading card has nothing before it. "Not preceded by another entry"
+       is true of whichever card leads, in either order, and is immune to the
+       rail divs, the flashback, and the script Vite injects between them in dev.
+       Do not narrow this to :first-child or an adjacent-sibling form — both
+       assume a fixed node layout and silently match nothing. */
+    .timeline-entry:not(.timeline-entry ~ .timeline-entry) .direction-cue {
         display: none;
     }
 ```
+
+**Do not use `:first-child` here, and do not "simplify" this selector.** This cost three review passes to catch.
+`#experienceTimeline`'s children are `#timelineLine`, `#timelineMarker`, then the entries — so the leading entry is
+the *third* child and `:first-child` matches nothing. The obvious repair, `#timelineMarker + .timeline-entry`, is also
+wrong: in `npm run dev`, Vite injects each component's hoisted script inline, so the marker's adjacent sibling is a
+`<script>`, not an entry. That form works in the production build (where scripts are bundled into `<head>`) and fails
+in dev — a split that hides the bug from anyone verifying against `dist/` alone. The `:not(... ~ ...)` form depends on
+no surrounding node layout at all. `CSS.supports('selector(.a:not(.a ~ .a))')` is true in current browsers.
 
 - [ ] **Step 3: Verify the build passes**
 

--- a/docs/superpowers/plans/2026-07-16-about-timeline-reading-direction.md
+++ b/docs/superpowers/plans/2026-07-16-about-timeline-reading-direction.md
@@ -1,0 +1,733 @@
+# About Timeline Reading Direction Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make the About page's newest-first experience timeline read as a deliberate walk backwards through time, and let readers opt into chronological "story order".
+
+**Architecture:** Phase 1 is pure markup and CSS — a descending start year on the timeline rail, a corrected kicker, a "How I got here" flashback sub-header, and a "Before that" cue chip. Phase 2 adds a `Latest first | Story order` toggle that flips a single class on a section wrapper and reverses the entry DOM nodes. All direction-dependent text is rendered twice and switched with CSS, so Phase 2's script never rewrites strings.
+
+**Tech Stack:** Astro 5, TypeScript, Tailwind CSS. Spec: `docs/superpowers/specs/2026-07-16-about-timeline-reading-direction-design.md`.
+
+---
+
+## Before you start: read this
+
+**There is no test framework in this repo.** `npm run check:build` (TypeScript check + Astro build) is the primary
+validation step for any change — this is stated in `CLAUDE.md`. So the usual TDD loop does not apply here. Every task
+below substitutes:
+
+1. `npm run check:build` must pass, and
+2. an explicit, scripted browser check with a stated expected observation.
+
+Do not add a test framework. That is out of scope and against the repo's conventions.
+
+**Two non-obvious things about this codebase you must not break:**
+
+1. **The traveling dot's math is hardcoded and fragile.** `src/pages/about.astro` contains
+   `const DOT_CENTER_OFFSET = 55;` with the comment `/* rail pt-12 (48) + half dot (7) */`. It assumes each entry's
+   dot centre sits 55px below the entry's top. If you change the rail column's vertical spacing without preserving
+   that 55px, the dot silently desyncs from the cards. Task 1 changes rail padding and **must** preserve it.
+2. **The rail script pairs DOM order with layout.** It uses `timeline.querySelectorAll('.timeline-entry')` (DOM
+   order) together with `offsetTop`. Never reorder entries with CSS `flex-direction: column-reverse` — visual and DOM
+   order would desync and the dot math would break. Phase 2 moves real DOM nodes for this reason.
+
+**Styling rule:** never hard-code palette values. Use the semantic tokens / shared classes (`.kicker`, `.cardx`,
+`.badge-accent`, `.badge-outline`, `.chip`) defined in `src/styles/global.css`.
+
+**Commit style:** this repo uses gerund-phrase commit subjects, e.g. "Rewriting the AMEK story as narrative prose".
+Match it. Do **not** add any Claude/AI attribution or `Co-Authored-By` trailer to commits, branches, or the PR.
+
+**Branch:** this plan is being executed from a git worktree on branch `worktree-about-timeline`, which is based on
+`feat/about-timeline-reading-direction` (which already contains the spec commit and is itself based on `dev`). Task 7
+reconciles the branches before opening the PR. The PR targets `dev`, never `main`.
+
+**Note on the working tree:** the *main* checkout has an unrelated uncommitted edit to
+`src/content/experiences/10-amek-senior-engineer.md`. It is not in this worktree and is not your concern. No task in
+this plan touches `src/content/experiences/`. Never use `git add -A` or `git commit -a`.
+
+---
+
+## File Structure
+
+| File | Responsibility | Change |
+|---|---|---|
+| `src/components/ExperienceCard.astro` | One timeline entry: rail column (year + dot) and story card | Modify |
+| `src/pages/about.astro` | Section wrapper, kicker, flashback sub-header, order toggle, direction CSS, toggle script | Modify |
+| `package.json` | Version | Modify (final task) |
+
+No new files. Phase 1 is confined to those two components; Phase 2 adds the control and script to `about.astro` only.
+
+---
+
+## Task 1: Descending start year on the rail
+
+Adds a muted start year above each dot, so the descent is legible before any copy is read. Desktop only — the mobile
+gutter is 28px and the card's meta line already carries dates.
+
+**The critical constraint:** the dot must not move. Its centre stays 55px below the entry top at **both**
+breakpoints, so `DOT_CENTER_OFFSET = 55` in `about.astro` keeps working untouched.
+
+| Breakpoint | Rail padding | Year | Gap | Dot top | Dot centre |
+|---|---|---|---|---|---|
+| mobile (year hidden) | `pt-12` = 48px | — | — | 48px | 55px |
+| md (year shown) | `pt-6` = 24px | 14px | 10px | 48px | 55px |
+
+**Files:**
+- Modify: `src/components/ExperienceCard.astro`
+
+- [ ] **Step 1: Derive the start year in the component frontmatter**
+
+In `src/components/ExperienceCard.astro`, find this line:
+
+```astro
+const workTypeLabel = workType.charAt(0).toUpperCase() + workType.slice(1);
+```
+
+Add directly below it:
+
+```astro
+const startYear = startDate.slice(0, 4);
+```
+
+`startDate` is already destructured from `experience.data` on the line above. Its schema format is `"YYYY-MM"`, so
+`slice(0, 4)` is the year. (`endDate` is *not* safe to slice — for the current role it is free text, `"Present"`.)
+
+- [ ] **Step 2: Render the year above the dot**
+
+In the same file, find the rail column:
+
+```astro
+<div class='flex flex-col items-center pt-12'>
+    <span class='w-3.5 h-3.5 rounded-full border-2 border-accent bg-surface relative z-[1] shrink-0'></span>
+</div>
+```
+
+Replace it with:
+
+```astro
+<div class='flex flex-col items-center pt-12 md:pt-6'>
+    <span class='hidden md:block text-[11px] font-semibold text-muted tabular-nums leading-[14px] mb-[10px]'>{startYear}</span>
+    <span class='w-3.5 h-3.5 rounded-full border-2 border-accent bg-surface relative z-[1] shrink-0'></span>
+</div>
+```
+
+Why each part matters:
+- `pt-12 md:pt-6` — 48px on mobile where the year is hidden; 24px on desktop where the year occupies the rest.
+- `hidden md:block` — hides the year on mobile.
+- `leading-[14px]` + `mb-[10px]` — pins the year's box to exactly 14px + 10px = 24px, so 24 + 24 = 48px puts the dot
+  top at the same place as mobile's `pt-12`. Do not change these numbers casually.
+- `tabular-nums` — equal-width digits so the years line up vertically down the rail.
+- `text-muted` — semantic token; the year is a quiet cue, not a headline.
+
+- [ ] **Step 3: Verify the build passes**
+
+Run: `npm run check:build`
+Expected: completes with `[build] Complete!` and no TypeScript errors.
+
+- [ ] **Step 4: Verify in the browser**
+
+Run: `npm run dev` and open `http://localhost:4321/about`.
+
+Expected observations:
+1. At desktop width, years run down the rail reading **2026, 2025, 2025, 2024, 2023, 2023, 2023, 2022, 2021, 2019**.
+   Repeated years are correct and intentional — three roles began in 2023. Do not "fix" them.
+2. The dot of each entry still sits vertically level with its card's role title, exactly as before the change.
+3. Scrolling: the accent traveling dot still lands on each entry's dot. **If it drifts, Step 2's spacing is wrong —
+   recheck the 14px/10px numbers before continuing.**
+4. Narrow the window below `md` (768px): years disappear, dots stay level with the titles.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/components/ExperienceCard.astro
+git commit -m "Adding descending start years to the about timeline rail"
+```
+
+---
+
+## Task 2: Direction-aware CSS foundation and corrected kicker
+
+The kicker currently reads `2019 → Today` while the list runs Today → 2019 — the label contradicts the order. This
+task fixes it and, in the same stroke, builds the CSS mechanism that Phase 2 depends on.
+
+**The mechanism:** every direction-dependent string is rendered **twice** — `.cue-back` (shown by default) and
+`.cue-forward` (hidden). An `.order-story` class on an ancestor swaps which is visible. Phase 2 therefore only
+toggles a class; it never rewrites text.
+
+`.order-story` must live on an ancestor of **both** the kicker and the timeline, so this task introduces a wrapper
+with `id='experienceSection'`.
+
+**Files:**
+- Modify: `src/pages/about.astro`
+
+- [ ] **Step 1: Add the section wrapper and rewrite the kicker**
+
+In `src/pages/about.astro`, find the experience section:
+
+```astro
+    <!-- Experience timeline -->
+    <section class='border-t border-hairline'>
+        <div class='shell py-[72px]'>
+            <p class='kicker mb-4'>2019 → Today · {experiences.length} roles</p>
+```
+
+Replace those four lines with:
+
+```astro
+    <!-- Experience timeline -->
+    <section class='border-t border-hairline'>
+        <div class='shell py-[72px]' id='experienceSection'>
+            <p class='kicker mb-4'>
+                <span class='cue-back'>Today → 2019</span><span class='cue-forward'>2019 → Today</span> · {experiences.length} roles
+            </p>
+```
+
+Keep the rest of the section exactly as it is.
+
+- [ ] **Step 2: Add the direction CSS**
+
+`src/pages/about.astro` already has a `<style is:global>` block containing `.timeline-entry .story-card` rules. These
+rules must be global (not Astro-scoped) because `.order-story` is set on an ancestor and the `.cue-*` spans live
+inside `ExperienceCard.astro` — a different component.
+
+Find the opening of that block:
+
+```css
+<style is:global>
+    .timeline-entry .story-card {
+```
+
+Insert these rules immediately after `<style is:global>` and before `.timeline-entry .story-card`:
+
+```css
+    /* Direction-dependent text is rendered twice; .order-story picks which shows.
+       This keeps the Phase 2 toggle to a single class flip — no string rewriting. */
+    .cue-forward {
+        display: none;
+    }
+
+    .order-story .cue-back {
+        display: none;
+    }
+
+    .order-story .cue-forward {
+        display: inline;
+    }
+```
+
+- [ ] **Step 3: Verify the build passes**
+
+Run: `npm run check:build`
+Expected: completes with `[build] Complete!` and no TypeScript errors.
+
+- [ ] **Step 4: Verify in the browser**
+
+Open `http://localhost:4321/about`.
+
+Expected: the kicker above the heading now reads **`Today → 2019 · 10 roles`**. The text `2019 → Today` must **not**
+be visible anywhere (it is in the DOM but hidden by `.cue-forward { display: none }`).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/pages/about.astro
+git commit -m "Correcting the about timeline kicker to match the reading direction"
+```
+
+---
+
+## Task 3: "Before that" cue chip on non-leading cards
+
+Adds a quiet cue above each role title marking the step backwards. It is self-correcting: hiding it on
+`.timeline-entry:first-child` means the leading card suppresses its own cue in **either** order, with no position
+logic and no JavaScript.
+
+**Files:**
+- Modify: `src/components/ExperienceCard.astro`
+- Modify: `src/pages/about.astro`
+
+- [ ] **Step 1: Render both cue variants in the card**
+
+In `src/components/ExperienceCard.astro`, find the card's header row:
+
+```astro
+    <div class='cardx p-6 md:p-10 mb-7 story-card'>
+        <div class='flex items-center gap-3 flex-wrap mb-3'>
+```
+
+Insert a cue line between those two lines, so it reads:
+
+```astro
+    <div class='cardx p-6 md:p-10 mb-7 story-card'>
+        <p class='direction-cue kicker mb-2'>
+            <span class='cue-back'>Before that</span><span class='cue-forward'>Then</span>
+        </p>
+        <div class='flex items-center gap-3 flex-wrap mb-3'>
+```
+
+`.kicker` is an existing shared class from `src/styles/global.css` — reuse it rather than inventing new type styles.
+The `.cue-back` / `.cue-forward` spans reuse the CSS built in Task 2.
+
+- [ ] **Step 2: Hide the cue on the leading card**
+
+In `src/pages/about.astro`, inside the same `<style is:global>` block, add this rule directly after the
+`.order-story .cue-forward` rule from Task 2:
+
+```css
+    /* The leading card has nothing before it — true in either order, so :first-child
+       handles both without position logic. */
+    .timeline-entry:first-child .direction-cue {
+        display: none;
+    }
+```
+
+- [ ] **Step 3: Verify the build passes**
+
+Run: `npm run check:build`
+Expected: completes with `[build] Complete!` and no TypeScript errors.
+
+- [ ] **Step 4: Verify in the browser**
+
+Open `http://localhost:4321/about`.
+
+Expected observations:
+1. The **first** card (Senior Software Engineer, AMEK Consulting) shows **no** cue above its title.
+2. Every **other** card shows a small `Before that` label above its role title.
+3. The word `Then` is not visible anywhere.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/components/ExperienceCard.astro src/pages/about.astro
+git commit -m "Adding a direction cue to the about timeline cards"
+```
+
+---
+
+## Task 4: "How I got here" flashback sub-header
+
+Inserts a sub-header after the first entry, reframing everything below as an explicit retrospective. This is what
+turns backwards reading from broken into intentional.
+
+It renders in the **content column**, not the rail, so the rail line runs unbroken behind it from first dot to last.
+It is a sibling of the `.timeline-entry` nodes and is deliberately **not** given that class — the rail script selects
+`.timeline-entry`, so the sub-header stays invisible to the dot math while still taking vertical space (which is
+harmless: the rail spans first dot to last dot regardless).
+
+**Files:**
+- Modify: `src/pages/about.astro`
+
+- [ ] **Step 1: Know that Fragment needs no import**
+
+`Fragment` is built into Astro and is available in every `.astro` template with no import. This step exists only so
+you do not go hunting for one. Proceed to Step 2.
+
+- [ ] **Step 2: Insert the sub-header after the first entry**
+
+In `src/pages/about.astro`, find the entry loop:
+
+```astro
+                {experiences.map((exp) => <ExperienceCard experience={exp}/>)}
+```
+
+Replace it with:
+
+```astro
+                {experiences.map((exp, index) => (
+                    <Fragment>
+                        <ExperienceCard experience={exp}/>
+                        {index === 0 && (
+                            <div id='timelineFlashback' class='grid grid-cols-[28px_1fr] md:grid-cols-[48px_1fr]'>
+                                <div></div>
+                                <p class='kicker mb-7'>How I got here</p>
+                            </div>
+                        )}
+                    </Fragment>
+                ))}
+```
+
+The empty `<div></div>` occupies the rail column so the text aligns with the cards, matching the
+`grid-cols-[28px_1fr] md:grid-cols-[48px_1fr]` used by `ExperienceCard`.
+
+- [ ] **Step 3: Verify the build passes**
+
+Run: `npm run check:build`
+Expected: completes with `[build] Complete!` and no TypeScript errors.
+
+- [ ] **Step 4: Verify in the browser**
+
+Open `http://localhost:4321/about`.
+
+Expected observations:
+1. `How I got here` appears once, between the first card (AMEK) and the second card (Solo Engineer).
+2. It is aligned with the left edge of the cards, not the rail.
+3. The rail line passes behind/beside it without a visible break.
+4. Scroll the full timeline: the traveling dot still lands on each entry's dot. The extra vertical space must not
+   have desynced it.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/pages/about.astro
+git commit -m "Framing the about timeline history as a flashback"
+```
+
+---
+
+## Task 5: Order toggle control (markup and styles)
+
+Phase 2 begins. This task adds the control only — it does nothing until Task 6 wires the script. Splitting it keeps
+each commit small and leaves the build working at every step.
+
+**Files:**
+- Modify: `src/pages/about.astro`
+
+- [ ] **Step 1: Add the control markup**
+
+In `src/pages/about.astro`, find the heading that follows the kicker:
+
+```astro
+            <h2 class='font-display text-4xl md:text-[44px] font-semibold text-strong leading-tight mb-12'>
+                The story behind my experience.
+            </h2>
+```
+
+Change its bottom margin from `mb-12` to `mb-6` and insert the control after it, so the block reads:
+
+```astro
+            <h2 class='font-display text-4xl md:text-[44px] font-semibold text-strong leading-tight mb-6'>
+                The story behind my experience.
+            </h2>
+            <div class='flex items-center gap-2 mb-12' id='orderControl'>
+                <span class='kicker'>Read</span>
+                <button type='button' class='order-btn chip' data-order='latest' aria-pressed='true'>Latest first</button>
+                <button type='button' class='order-btn chip' data-order='story' aria-pressed='false'>Story order</button>
+            </div>
+```
+
+`.chip` is an existing shared class from `src/styles/global.css`.
+
+- [ ] **Step 2: Style the selected state**
+
+In `src/pages/about.astro`'s `<style is:global>` block, add after the `.timeline-entry:first-child` rule from Task 3:
+
+```css
+    .order-btn {
+        cursor: pointer;
+    }
+
+    .order-btn[aria-pressed='true'] {
+        background: var(--accent-wash);
+        color: var(--text-strong);
+        font-weight: 600;
+    }
+```
+
+`--accent-wash` is an existing token — it is already used by the timeline marker's box-shadow in this same file.
+
+- [ ] **Step 3: Verify the build passes**
+
+Run: `npm run check:build`
+Expected: completes with `[build] Complete!` and no TypeScript errors.
+
+- [ ] **Step 4: Verify in the browser**
+
+Open `http://localhost:4321/about`.
+
+Expected: a `Read  [Latest first] [Story order]` control sits between the heading and the timeline. `Latest first` is
+visibly emphasised. Clicking either button does nothing yet — that is correct at this stage.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/pages/about.astro
+git commit -m "Adding the reading order control to the about timeline"
+```
+
+---
+
+## Task 6: Order toggle behaviour
+
+Wires the control. Three rules govern this code:
+
+1. **Move real DOM nodes.** Never `column-reverse` (see "Before you start").
+2. **Never rewrite strings.** Direction text flips via the `.order-story` class from Task 2.
+3. **Re-run the rail math after reordering** by dispatching a `resize` event. The existing script's `update()` is
+   closed over and not exported; it already listens for `resize`. Dispatching one is far safer than refactoring it.
+
+**Files:**
+- Modify: `src/components/ExperienceCard.astro`
+- Modify: `src/pages/about.astro`
+
+- [ ] **Step 1: Tag each entry with its render index**
+
+The script needs a stable notion of original order, because after one reversal the DOM no longer tells you.
+
+In `src/components/ExperienceCard.astro`, find:
+
+```astro
+export interface Props {
+    experience: CollectionEntry<'experiences'>;
+}
+
+const {experience} = Astro.props;
+```
+
+Replace with:
+
+```astro
+export interface Props {
+    experience: CollectionEntry<'experiences'>;
+    index: number;
+}
+
+const {experience, index} = Astro.props;
+```
+
+Then find the entry's root element:
+
+```astro
+<div class='timeline-entry grid grid-cols-[28px_1fr] md:grid-cols-[48px_1fr] reveal'>
+```
+
+Replace with:
+
+```astro
+<div class='timeline-entry grid grid-cols-[28px_1fr] md:grid-cols-[48px_1fr] reveal' data-index={index}>
+```
+
+And in `src/pages/about.astro`, pass it — find the line introduced in Task 4:
+
+```astro
+                        <ExperienceCard experience={exp}/>
+```
+
+Replace with:
+
+```astro
+                        <ExperienceCard experience={exp} index={index}/>
+```
+
+- [ ] **Step 2: Add the toggle script**
+
+In `src/pages/about.astro`, add this as a **new** `<script is:inline>` block after the existing timeline script block
+(the one ending with the `ResizeObserver` and its closing `</script>`). Do not merge it into that block.
+
+```astro
+<script is:inline>
+    if (!window.__orderToggleBound) {
+        window.__orderToggleBound = true;
+
+        const STORAGE_KEY = 'experienceOrder';
+
+        const applyOrder = (order) => {
+            const section = document.getElementById('experienceSection');
+            const timeline = document.getElementById('experienceTimeline');
+            const flashback = document.getElementById('timelineFlashback');
+            if (!section || !timeline) return;
+
+            // Sort back to render order first; after a reversal the DOM is no longer authoritative.
+            const entries = Array.from(timeline.querySelectorAll('.timeline-entry'))
+                .sort((a, b) => Number(a.dataset.index) - Number(b.dataset.index));
+            const ordered = order === 'story' ? entries.slice().reverse() : entries;
+
+            // Moving real nodes, not CSS column-reverse: the rail script pairs
+            // querySelectorAll order with offsetTop and would desync otherwise.
+            ordered.forEach((entry) => timeline.appendChild(entry));
+
+            // The flashback frame only makes sense walking backwards; in story order
+            // the current role is last, so it is hidden by CSS and its position is moot.
+            if (flashback) timeline.insertBefore(flashback, ordered[1] ?? null);
+
+            section.classList.toggle('order-story', order === 'story');
+
+            document.querySelectorAll('.order-btn').forEach((button) => {
+                button.setAttribute('aria-pressed', String(button.dataset.order === order));
+            });
+
+            // The rail's update() is closed over; it already listens for resize.
+            window.dispatchEvent(new Event('resize'));
+        };
+
+        const readStoredOrder = () => {
+            try {
+                return localStorage.getItem(STORAGE_KEY) === 'story' ? 'story' : 'latest';
+            } catch {
+                return 'latest';
+            }
+        };
+
+        document.addEventListener('click', (event) => {
+            const button = event.target?.closest?.('.order-btn');
+            if (!button) return;
+            const order = button.dataset.order;
+            try {
+                localStorage.setItem(STORAGE_KEY, order);
+            } catch {
+                /* private mode — the toggle still works for this page view */
+            }
+            applyOrder(order);
+        });
+
+        // Re-apply on first load and after each View Transitions navigation.
+        document.addEventListener('astro:page-load', () => applyOrder(readStoredOrder()));
+    }
+</script>
+```
+
+Notes on the choices, so you do not "simplify" them into bugs:
+- The `try/catch` around `localStorage` mirrors how theme persistence is handled and keeps private browsing from
+  throwing.
+- `ordered[1] ?? null` — `insertBefore` with `null` appends, which is the correct fallback if there is only one entry.
+- The `window.__orderToggleBound` guard matches the existing `__timelineBound` / `__storyToggleBound` pattern in this
+  repo and prevents double-binding across View Transitions.
+
+- [ ] **Step 3: Verify the build passes**
+
+Run: `npm run check:build`
+Expected: completes with `[build] Complete!` and no TypeScript errors.
+
+- [ ] **Step 4: Verify in the browser**
+
+Open `http://localhost:4321/about`.
+
+Expected observations:
+1. Click `Story order`. The entries reverse: AMEK is now **last**, Sweedy Portal (2019) **first**. Rail years now
+   ascend 2019 → 2026.
+2. The kicker flips to `2019 → Today · 10 roles`.
+3. `How I got here` disappears.
+4. Cue chips now read `Then` instead of `Before that`, and the **first** card (Sweedy Portal, 2019) shows none.
+5. Scroll: the traveling dot still lands on each entry's dot. **This is the check most likely to fail — if it drifts,
+   the `resize` dispatch is not reaching `update()`.**
+6. Reload the page: story order persists.
+7. Click `Latest first`: AMEK returns to the top and `How I got here` reappears between the first and second cards
+   (not at the very top — if it is at the top, the `insertBefore` is wrong).
+8. Navigate to `/` and back to `/about` via the header links (this uses View Transitions): the saved order re-applies
+   and the buttons do not double-bind.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/pages/about.astro src/components/ExperienceCard.astro
+git commit -m "Wiring the reading order toggle on the about timeline"
+```
+
+---
+
+## Task 7: Version bump, branch reconciliation, and pull request
+
+This repo bumps `package.json` per semver in every PR. This work adds a user-facing feature, so it is a **minor**
+bump: `1.1.1` → `1.2.0`.
+
+**Files:**
+- Modify: `package.json`
+
+- [ ] **Step 1: Bump the version**
+
+In `package.json`, change:
+
+```json
+  "version": "1.1.1",
+```
+
+to:
+
+```json
+  "version": "1.2.0",
+```
+
+- [ ] **Step 2: Verify the build passes**
+
+Run: `npm run check:build`
+Expected: completes with `[build] Complete!` and no TypeScript errors.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add package.json
+git commit -m "Bumping version to 1.2.0"
+```
+
+- [ ] **Step 4: Confirm nothing unrelated was committed**
+
+Run: `git log --oneline feat/about-timeline-reading-direction..HEAD`
+Expected: exactly six commits, Task 1 through Task 7, in order.
+
+Run: `git diff --name-only feat/about-timeline-reading-direction..HEAD`
+Expected: exactly three paths — `package.json`, `src/components/ExperienceCard.astro`, `src/pages/about.astro`.
+Nothing under `src/content/` may appear. If it does, stop and report it.
+
+- [ ] **Step 5: Reconcile the branches**
+
+This plan's commits are on `worktree-about-timeline`; the spec lives on `feat/about-timeline-reading-direction`, which
+is this branch's base and therefore already an ancestor. Fast-forward the feature branch onto the work, from the
+**main checkout** (a branch cannot be checked out in two worktrees at once):
+
+```bash
+git -C /Users/joeinz/Workspace/personal/Projects/Web/personal-website \
+  branch -f feat/about-timeline-reading-direction worktree-about-timeline
+```
+
+Note: the main checkout currently has `feat/about-timeline-reading-direction` checked out, so `branch -f` will be
+refused. If that happens, switch it to `dev` first, then retry:
+
+```bash
+git -C /Users/joeinz/Workspace/personal/Projects/Web/personal-website switch dev
+```
+
+Switching is safe: the uncommitted AMEK edit follows the working tree and is not lost.
+
+- [ ] **Step 6: Push and open the draft PR**
+
+```bash
+git push -u origin feat/about-timeline-reading-direction
+gh pr create --draft --base dev --assignee joeloudjinz \
+  --title "Reading direction on the about timeline" \
+  --body "$(cat <<'EOF'
+The experience entries read as a story, but the timeline runs newest-first, so reading top-to-bottom meant reading the story backwards. The kicker also said `2019 → Today` while the list ran the other way.
+
+Keeps newest-first as the default and makes the descent deliberate: start years descend down the rail, the kicker matches the order, a "How I got here" sub-header frames the history as a flashback, and each card carries a "Before that" cue.
+
+Adds a `Latest first | Story order` toggle for readers who want the story in order. It persists in localStorage and flips direction text via a single CSS class.
+
+Design: `docs/superpowers/specs/2026-07-16-about-timeline-reading-direction-design.md`
+EOF
+)"
+```
+
+Keep the PR description short and straightforward. Do not add AI attribution.
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+
+| Spec requirement | Task |
+|---|---|
+| Years on the rail, descending, desktop only | 1 |
+| `DOT_CENTER_OFFSET` / rail geometry unchanged | 1 (table + Step 4 check 3) |
+| Repeated years accepted, not suppressed | 1 (Step 4 check 1) |
+| Kicker corrected to `Today → 2019` | 2 |
+| Direction text is CSS-driven, never rewritten | 2 (mechanism), 6 (consumes it) |
+| No directional connectives in markdown | Honoured — no task touches `src/content/experiences/` |
+| Flashback sub-header in content column, not a `.timeline-entry` | 4 |
+| "Now" hero already exists (Current badge + expanded by default) | No task needed — spec states this is pre-existing |
+| Cue chip, hidden on `:first-child`, self-correcting | 3 |
+| Toggle: persists, reverses DOM nodes, hides sub-header, flips kicker, re-runs `update()` | 5, 6 |
+| Reversal moves DOM nodes, never `column-reverse` | 6 (Step 2 comment + "Before you start") |
+| Out of scope: 3-line clamp, chapter counters, reordering the default | No tasks — correctly absent |
+| Verification: `check:build` + dot tracking at both widths | Every task, Steps 3–4 |
+
+No gaps.
+
+**Placeholder scan:** none. Every step names exact files, shows the actual code, and states an expected observation.
+
+**Type consistency:** `startYear` (Task 1) is used only in Task 1. The `index` prop (Task 6 Step 1) is declared in
+`Props`, destructured, rendered as `data-index`, and read as `dataset.index` in the same task. `.cue-back` /
+`.cue-forward` are defined in Task 2 and reused verbatim in Tasks 3 and 6. `.order-story` is defined in Task 2 and set
+in Task 6 on `#experienceSection`, the wrapper Task 2 introduces. `#timelineFlashback` is created in Task 4 and read
+in Task 6. `.order-btn` is created in Task 5 and read in Task 6. Consistent throughout.
+
+**Ordering dependency:** Task 4 introduces the `(exp, index)` map signature, and Task 6 Step 1 reuses that `index`
+when passing it to `ExperienceCard`. Task 6 depends on Task 4 having landed. Execute in order.

--- a/docs/superpowers/plans/2026-07-16-about-timeline-reading-direction.md
+++ b/docs/superpowers/plans/2026-07-16-about-timeline-reading-direction.md
@@ -338,16 +338,24 @@ Replace it with:
                         <ExperienceCard experience={exp}/>
                         {index === 0 && (
                             <div id='timelineFlashback' class='grid grid-cols-[28px_1fr] md:grid-cols-[48px_1fr]'>
-                                <div></div>
-                                <p class='kicker mb-7'>How I got here</p>
+                                <div aria-hidden='true'></div>
+                                <h3 class='kicker mb-7'>How I got here</h3>
                             </div>
                         )}
                     </Fragment>
                 ))}
 ```
 
-The empty `<div></div>` occupies the rail column so the text aligns with the cards, matching the
-`grid-cols-[28px_1fr] md:grid-cols-[48px_1fr]` used by `ExperienceCard`.
+The empty `<div>` occupies the rail column so the text aligns with the cards, matching the
+`grid-cols-[28px_1fr] md:grid-cols-[48px_1fr]` used by `ExperienceCard`. It is `aria-hidden` to match how
+`#timelineMarker` and `#timelineLine` already mark presentational elements in this file.
+
+**Why `<h3>` and not `<p>`:** this sub-header's whole job is to reframe everything below it as a retrospective. As a
+`<p class='kicker'>` it would be the only kicker in the codebase that neither precedes a heading nor sits in a
+landmark — meaning a screen-reader user navigating by heading outline would never encounter it, and the reframing
+cue would be lost for exactly the users who most need explicit structure. `<h3>` keeps heading order valid: the
+section's `<h2>` is "The story behind my experience.", role titles are `<h3>`, so the sequence stays
+`h2 → h3 → h3 → …` with no skipped levels.
 
 - [ ] **Step 3: Verify the build passes**
 

--- a/docs/superpowers/plans/2026-07-17-story-typing-reveal.md
+++ b/docs/superpowers/plans/2026-07-17-story-typing-reveal.md
@@ -209,20 +209,28 @@ block (the one ending with the `astro:after-swap` listener). Do not merge it int
                     growTimer: 0, typing: false};
         };
 
-        /* Restore text up to character `upto`; empty everything after. Returns the last
-           node holding revealed text, which is where the cursor goes. */
+        /* Restore text up to character `upto`; empty everything after. Returns the last node
+           holding revealed, non-whitespace text — the anchor for both the ellipsis and the
+           cursor.
+
+           Whitespace-only nodes MUST be skipped. Markdown renders `<p>…</p>\n<p>…</p>`, so
+           the `\n` between paragraphs is a text node whose parent is the `.story` div, not a
+           paragraph. Anchoring to it puts the cursor in BLOCK context, which forces an
+           anonymous block box costing a full line-height (measured +25.56px), and would put
+           the ellipsis on a newline node. */
         const reveal = (story, upto, ellipsis) => {
             const s = state.get(story);
             let tail = null;
             for (const item of s.nodes) {
                 if (item.end <= upto) {
                     if (item.node.nodeValue !== item.full) item.node.nodeValue = item.full;
-                    if (item.full.length) tail = item;
+                    if (item.full.trim()) tail = item;
                 } else if (item.start >= upto) {
                     if (item.node.nodeValue !== '') item.node.nodeValue = '';
                 } else {
-                    item.node.nodeValue = item.full.slice(0, upto - item.start);
-                    tail = item;
+                    const shown = item.full.slice(0, upto - item.start);
+                    item.node.nodeValue = shown;
+                    if (shown.trim()) tail = item;
                 }
             }
             for (const b of s.blocks) {
@@ -482,11 +490,12 @@ In the same script, insert these three functions directly above `const expand = 
             }
         };
 
-        const placeCursor = (story, upto) => {
+        /* Takes the tail `reveal` already computed. Do not re-derive it here: a second scan
+           with slightly different rules is a second definition of "the tail" that can drift
+           out of agreement, and it costs an extra O(n) pass every frame. */
+        const placeCursor = (story, tail) => {
             const s = state.get(story);
-            if (!s.cursor) return;
-            let tail = s.nodes[0];
-            for (const item of s.nodes) if (item.start < upto) tail = item;
+            if (!s.cursor || !tail) return;
             const parent = tail.node.parentNode;
             if (parent && s.cursor.previousSibling !== tail.node) {
                 parent.insertBefore(s.cursor, tail.node.nextSibling);
@@ -527,8 +536,7 @@ In the same script, insert these three functions directly above `const expand = 
                     acc -= delayAt(revealed - from);
                     revealed++;
                 }
-                reveal(story, revealed);
-                placeCursor(story, revealed);
+                placeCursor(story, reveal(story, revealed));
                 if (revealed >= s.total) {
                     finish(story);
                     return;
@@ -567,9 +575,11 @@ Replace the `expand` function from Task 1 entirely:
                06-teknika-backend-lead, and 0.98-1.02 line-heights across all eight stories,
                which is what makes one line a safe bound.
  
-               The cursor is NOT the cause here: it is width:0 with an absolutely-positioned
-               ::after and measures 0x0, verified layout-neutral. Do not "fix" this by
-               padding for the cursor.
+               The cursor is not the cause: it is width:0 with an absolutely-positioned
+               ::after. (Its own rect measures 0x0, but note that measuring the cursor's rect
+               cannot detect the case where it lands in block context — `reveal` skipping
+               whitespace-only nodes is what prevents that.) Do not "fix" this by padding for
+               the cursor.
  
                min-height needs an explicit start value — auto will not transition. */
             const lineHeight = parseFloat(getComputedStyle(story).lineHeight) || 0;
@@ -717,6 +727,10 @@ In the reveal script, replace `initStories` and its two call sites:
         }, {threshold: 0});
 
         const initStories = () => {
+            /* IntersectionObserver holds STRONG references to its targets, and View
+               Transitions replace the cards on every navigation — without this, each return
+               to /about leaks the previous set. */
+            offscreenObserver.disconnect();
             document.querySelectorAll('.story').forEach((story) => {
                 if (!state.has(story)) state.set(story, buildState(story));
                 if (story.classList.contains('collapsed')) truncate(story);
@@ -725,6 +739,19 @@ In the reveal script, replace `initStories` and its two call sites:
         };
         initStories();
         document.addEventListener('astro:after-swap', initStories);
+
+        /* The cut is measured against a specific box width, so it goes stale the moment the
+           box changes width — window snap, phone rotation, zoom, devtools. The old
+           `max-height: 77px` clamp was viewport-independent and could not fail this way;
+           `.collapsed` now carries no CSS at all, so nothing else catches it. Measured
+           without this: resizing 1600px -> 760px rendered collapsed cards at up to 6 lines
+           instead of 3. initStories is idempotent and only re-cuts collapsed stories, so an
+           expanded or mid-run card is left alone. */
+        let resizeTimer = 0;
+        window.addEventListener('resize', () => {
+            clearTimeout(resizeTimer);
+            resizeTimer = setTimeout(initStories, 150);
+        }, {passive: true});
 ```
 
 - [ ] **Step 4: Verify the build passes**

--- a/docs/superpowers/plans/2026-07-17-story-typing-reveal.md
+++ b/docs/superpowers/plans/2026-07-17-story-typing-reveal.md
@@ -556,12 +556,26 @@ Replace the `expand` function from Task 1 entirely:
             const fullHeight = story.scrollHeight;
             reveal(story, s.cut, true);
 
-            /* Reserve the space before typing so nothing below the card shifts while the
-               reader reads. min-height needs an explicit start value — auto will not
-               transition. */
+            /* Reserve ONE LINE MORE than the finished text needs.
+ 
+               `p { text-wrap: pretty }` (global.css) rebalances a paragraph to avoid
+               orphans. A half-typed paragraph is a complete paragraph as far as CSS is
+               concerned, so mid-run it can push its last word onto an extra line and render
+               TALLER than the same paragraph will once fully revealed. Reserving only
+               fullHeight therefore leaves the box overflowing by one line for part of the
+               run, jittering everything below it — measured at exactly +25px on
+               06-teknika-backend-lead, and 0.98-1.02 line-heights across all eight stories,
+               which is what makes one line a safe bound.
+ 
+               The cursor is NOT the cause here: it is width:0 with an absolutely-positioned
+               ::after and measures 0x0, verified layout-neutral. Do not "fix" this by
+               padding for the cursor.
+ 
+               min-height needs an explicit start value — auto will not transition. */
+            const lineHeight = parseFloat(getComputedStyle(story).lineHeight) || 0;
             story.style.minHeight = story.offsetHeight + 'px';
             void story.offsetHeight;
-            story.style.minHeight = fullHeight + 'px';
+            story.style.minHeight = fullHeight + lineHeight + 'px';
 
             /* Cancel any grow timer still pending from a previous expand. Without this, a
                fast expand -> collapse -> expand inside the 340ms grow window leaves a stale

--- a/docs/superpowers/plans/2026-07-17-story-typing-reveal.md
+++ b/docs/superpowers/plans/2026-07-17-story-typing-reveal.md
@@ -67,6 +67,13 @@ the working tree — that is pre-existing drift. Leave it. Never `git add -A` or
   3-line boundary is immune to both.
 - `experience.id` resolves via the `glob()` loader in `src/content.config.ts` to the filename slug, e.g.
   `10-amek-senior-engineer` — verified, and valid/unique as an HTML id.
+- **`src/styles/global.css:118` sets `p { text-wrap: pretty }`.** This is pre-existing, part of the design system's
+  original tokens commit. It is the single most important fact on this page, because **line breaking is not greedy**:
+  `pretty` rebalances a paragraph's breaks across its whole content, so shortening a paragraph re-wraps the text that
+  remains. A boundary measured against the full story therefore stops being true the moment it is applied — measured
+  in a real browser, two of nine cards rendered 4 lines instead of 3 from exactly this. `truncate` handles it by
+  re-measuring what it actually rendered and tightening (converges in 1-2 passes). Do **not** "fix" this by setting
+  `text-wrap: auto` on the story: that is a design-system typography choice, and the brief was to respect it.
 
 ## File Structure
 
@@ -224,13 +231,17 @@ block (the one ending with the `astro:after-swap` listener). Do not merge it int
             return tail;
         };
 
-        /* Top of the character at `index`, or null if it has no box (collapsed whitespace). */
+        /* Top of the character at `index`, or null if it has no box (collapsed whitespace)
+           or has not been revealed yet. The length guard matters: after a cut, nodes past
+           the cut hold '', and setStart past a node's length throws IndexSizeError. */
         const rectTopAt = (s, index) => {
             for (const item of s.nodes) {
                 if (index >= item.start && index < item.end) {
+                    const offset = index - item.start;
+                    if (offset + 1 > item.node.nodeValue.length) return null;
                     const range = document.createRange();
-                    range.setStart(item.node, index - item.start);
-                    range.setEnd(item.node, index - item.start + 1);
+                    range.setStart(item.node, offset);
+                    range.setEnd(item.node, offset + 1);
                     const rect = range.getBoundingClientRect();
                     return rect.height ? rect.top : null;
                 }
@@ -238,20 +249,21 @@ block (the one ending with the `astro:after-swap` listener). Do not merge it int
             return null;
         };
 
-        /* First character index that falls below `lines` lines. Binary search, not a linear
-           walk: tops increase monotonically down the flow, so this costs ~11 probes per
-           story instead of ~2000. Nothing is mutated during the search, so the layout read
-           stays cached. */
-        const lineBoundary = (story, lines) => {
+        /* First character index that falls below `lines` lines, searching only up to
+           `hiBound`. Binary search, not a linear walk: tops increase monotonically down the
+           flow, so this costs ~11 probes per story instead of ~2000. Nothing is mutated
+           during the search, so the layout read stays cached. */
+        const lineBoundary = (story, lines, hiBound) => {
             const s = state.get(story);
             const lineHeight = parseFloat(getComputedStyle(story).lineHeight);
             if (!lineHeight) return s.total;
+            const limitIndex = Math.min(hiBound === undefined ? s.total : hiBound, s.total);
             let firstTop = null;
-            for (let i = 0; i < s.total && firstTop === null; i++) firstTop = rectTopAt(s, i);
-            if (firstTop === null) return s.total;
+            for (let i = 0; i < limitIndex && firstTop === null; i++) firstTop = rectTopAt(s, i);
+            if (firstTop === null) return limitIndex;
             const limit = firstTop + lines * lineHeight - 1;
             let lo = 0;
-            let hi = s.total;
+            let hi = limitIndex;
             while (lo < hi) {
                 const mid = (lo + hi) >> 1;
                 const top = rectTopAt(s, mid);
@@ -264,15 +276,32 @@ block (the one ending with the `astro:after-swap` listener). Do not merge it int
         const truncate = (story) => {
             const s = state.get(story);
             reveal(story, s.total); /* measure against the full text */
-            const boundary = lineBoundary(story, LINES);
+            const full = s.nodes.map((n) => n.full).join('');
+            const backOff = (index) => {
+                const space = full.slice(0, index).lastIndexOf(' ');
+                return space > 0 ? space : index;
+            };
+
+            const boundary = lineBoundary(story, LINES, s.total);
             if (boundary >= s.total) {
                 s.cut = s.total;
                 return;
             }
-            const full = s.nodes.map((n) => n.full).join('');
-            const space = full.slice(0, boundary).lastIndexOf(' ');
-            s.cut = space > 0 ? space : boundary;
+            s.cut = backOff(boundary);
             reveal(story, s.cut, true);
+
+            /* global.css sets `p { text-wrap: pretty }`, which rebalances a paragraph's
+               line breaks across its WHOLE content. Line breaking is therefore not greedy:
+               cutting text changes how the text that remains wraps, so a boundary measured
+               against the full story can render one line too tall once applied. Measure
+               what was actually rendered and tighten until it fits. Converges in 1-2
+               passes; the bound stops it probing the emptied nodes past the cut. */
+            for (let pass = 0; pass < 4; pass++) {
+                const rendered = lineBoundary(story, LINES, s.cut);
+                if (rendered >= s.cut) break;
+                s.cut = backOff(rendered);
+                reveal(story, s.cut, true);
+            }
         };
 
         const expand = (story, button) => {

--- a/docs/superpowers/plans/2026-07-17-story-typing-reveal.md
+++ b/docs/superpowers/plans/2026-07-17-story-typing-reveal.md
@@ -205,7 +205,8 @@ block (the one ending with the `astro:after-swap` listener). Do not merge it int
                     end: inside.length ? inside[inside.length - 1].end : 0
                 };
             });
-            return {nodes: nodes, blocks: blocks, total: offset, cut: offset, cursor: null, raf: 0, typing: false};
+            return {nodes: nodes, blocks: blocks, total: offset, cut: offset, cursor: null, raf: 0,
+                    growTimer: 0, typing: false};
         };
 
         /* Restore text up to character `upto`; empty everything after. Returns the last
@@ -398,18 +399,32 @@ delays and reveals however many characters that buys: ~5 per frame on the longes
 In `src/pages/about.astro`'s `<style is:global>` block, add after the `.order-btn[aria-pressed='true']` rule:
 
 ```css
-    /* The cursor is created by script, so it cannot live in ExperienceCard's scoped styles. */
+    /* The cursor is created by script, so it cannot live in ExperienceCard's scoped styles.
+
+       It MUST occupy zero width in the flow. It is inserted at the write head on every
+       frame, so if it took real inline width it would wrap onto a new line whenever the
+       write head neared the end of a full line — pushing the box past the min-height
+       reserved before it existed, which is the exact layout shift the grow-then-type
+       sequence exists to prevent. Measured: reserved 497px vs 522px actual. The block is
+       therefore painted by an absolutely-positioned ::after, which is outside the flow. */
     .type-cursor {
+        position: relative;
         display: inline-block;
+        width: 0;
+    }
+
+    .type-cursor::after {
+        content: '';
+        position: absolute;
+        left: 1px;
+        bottom: 0;
         width: 0.5em;
         height: 1em;
-        margin-left: 1px;
-        vertical-align: text-bottom;
         background: var(--accent);
         animation: type-blink 1s steps(2, start) infinite;
     }
 
-    .type-cursor.is-done {
+    .type-cursor.is-done::after {
         animation: none;
         opacity: 0;
         transition: opacity var(--dur-base) var(--ease-standard);
@@ -422,7 +437,7 @@ In `src/pages/about.astro`'s `<style is:global>` block, add after the `.order-bt
     }
 
     @media (prefers-reduced-motion: reduce) {
-        .type-cursor {
+        .type-cursor::after {
             animation: none;
         }
     }
@@ -452,6 +467,8 @@ In the same script, insert these three functions directly above `const expand = 
 ```js
         const finish = (story) => {
             const s = state.get(story);
+            if (s.growTimer) clearTimeout(s.growTimer);
+            s.growTimer = 0;
             if (s.raf) cancelAnimationFrame(s.raf);
             s.raf = 0;
             s.typing = false;
@@ -546,7 +563,16 @@ Replace the `expand` function from Task 1 entirely:
             void story.offsetHeight;
             story.style.minHeight = fullHeight + 'px';
 
-            setTimeout(() => type(story), GROW_MS);
+            /* Cancel any grow timer still pending from a previous expand. Without this, a
+               fast expand -> collapse -> expand inside the 340ms grow window leaves a stale
+               timeout that fires type() a second time, and two rAF loops then race over the
+               same story sharing s.raf/s.cursor with last-write-wins — orphaning one loop
+               forever. Reproduced: three quick clicks produced two live cursors. */
+            if (s.growTimer) clearTimeout(s.growTimer);
+            s.growTimer = setTimeout(() => {
+                s.growTimer = 0;
+                type(story);
+            }, GROW_MS);
         };
 ```
 
@@ -560,6 +586,8 @@ Replace the `collapse` function from Task 1 entirely:
 ```js
         const collapse = (story, button) => {
             const s = state.get(story);
+            if (s.growTimer) clearTimeout(s.growTimer); /* a run scheduled but not yet started */
+            s.growTimer = 0;
             if (s.raf) cancelAnimationFrame(s.raf);
             s.raf = 0;
             s.typing = false;

--- a/docs/superpowers/plans/2026-07-17-story-typing-reveal.md
+++ b/docs/superpowers/plans/2026-07-17-story-typing-reveal.md
@@ -1,0 +1,795 @@
+# Story Typing Reveal Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** When a reader expands an About page experience card, the hidden part of the story is written out with a terminal-style cursor instead of appearing instantly.
+
+**Architecture:** All story logic consolidates into one `is:inline` script in `about.astro` so it can run before first paint. A `TreeWalker` builds a flat character map over the story's text nodes; truncation and reveal are both "restore text nodes up to character N". A `requestAnimationFrame` accumulator loop drives the reveal, because the required per-character delays are far below one frame.
+
+**Tech Stack:** Astro 5, TypeScript, Tailwind CSS. Spec: `docs/superpowers/specs/2026-07-17-story-typing-reveal-design.md`.
+
+---
+
+## Before you start: read this
+
+**There is no test framework in this repo.** `npm run check:build` is the primary validation step per `CLAUDE.md`. Do
+not add a test framework. Each task gates on the build plus a scripted browser check.
+
+**`dist/` inspection is NOT sufficient verification.** The previous feature on this branch shipped a CSS selector that
+matched zero elements; it passed three reviews because each verified the rule *existed in the compiled CSS*, never that
+it *matched*. Worse, dev and production DOM differ (Vite injects component scripts inline in dev; production bundles
+them into `<head>`). **Verify in a real browser against `npm run dev`.**
+
+**Five things about this codebase you must not break:**
+
+1. **`DOT_CENTER_OFFSET = 55`** in `src/pages/about.astro` drives a scroll-following "traveling dot". Do not touch that
+   script. Story height changes are picked up by an existing `ResizeObserver` on `documentElement`.
+2. **`.timeline-entry:not(.timeline-entry ~ .timeline-entry)`** hides the leading card's direction cue. Do not
+   "simplify" it to `:first-child` or an adjacent-sibling form — both silently match nothing. This is documented at
+   length in `docs/superpowers/plans/2026-07-16-about-timeline-reading-direction.md`.
+3. **Direction text is rendered twice and switched by CSS** (`.cue-back` / `.cue-forward` under `.order-story`). Never
+   rewrite those strings in JS.
+4. **The order toggle reverses real DOM nodes.** Never reorder entries with CSS `column-reverse`.
+5. **`is:inline` scripts in `about.astro` run before paint** and are guarded with `window.__*Bound` flags because the
+   site uses View Transitions. Follow that pattern exactly.
+
+**Styling rule:** never hard-code palette values. Use semantic tokens (`--accent`, `--ease-standard`, `--dur-base`).
+
+**Commit style:** gerund-phrase subjects ("Adding…", "Wiring…"). **No** Claude/AI attribution or `Co-Authored-By`
+trailer in commits, branches, or PRs.
+
+**Branch:** `worktree-about-timeline` in a git worktree. Task 4 reconciles branches. PR targets `dev`, never `main`.
+
+**Do not touch** `package.json` dependencies or `package-lock.json`. `package-lock.json` may already show as modified in
+the working tree — that is pre-existing drift. Leave it. Never `git add -A` or `git commit -a`.
+
+---
+
+## Key facts established before writing this plan
+
+- **`ExperienceCard.astro` is rendered only by `about.astro`.** Confirmed by grep. Moving its script is therefore safe.
+- **`ExperienceCard.astro`'s `<script>` (line 99) is a bundled module script**, which is deferred and runs *after* first
+  paint. Truncating there would flash the full story. This is why the logic must move to an `is:inline` script in
+  `about.astro`. An `is:inline` script inside the component is not an option — Astro renders it once per instance, so
+  it would be duplicated ten times.
+- Removing that component script also removes the `<script>` node Vite injects between `#timelineMarker` and the first
+  `.timeline-entry` in dev. That node is what broke the earlier cue selector. The current selector does not depend on
+  it either way — do not "re-simplify" the selector just because the node is gone.
+- Only `09-solo-engineer.md` contains rich markup (a bullet list). It must survive truncation and typing intact.
+- **The teaser length is measured, not a constant — and this was corrected during plan review.** An earlier draft
+  hardcoded "~200 chars desktop / ~120 mobile". Measured in a real browser, both are wrong: at 1440px the `.story` box
+  is **1118px** wide and three lines hold **376 characters**; 200 would render ~1.4 lines, a visible regression against
+  today's 3-line clamp. (`77px ÷ 25.575px line-height = 3.01 lines` confirms 77px was a 3-line design.)
+- **The responsive split was removed, because it is currently meaningless.** At a 390px viewport the `.story` box is
+  still **874px** wide — the card never narrows. That is a pre-existing horizontal-overflow bug on this site (the home
+  page overflows too; it is not caused by this branch or the previous one). Hardcoding a "mobile" budget would bake in
+  a number derived from a broken layout and silently regress the day someone fixes the overflow. Measuring the real
+  3-line boundary is immune to both.
+- `experience.id` resolves via the `glob()` loader in `src/content.config.ts` to the filename slug, e.g.
+  `10-amek-senior-engineer` — verified, and valid/unique as an HTML id.
+
+## File Structure
+
+| File | Responsibility | Change |
+|---|---|---|
+| `src/components/ExperienceCard.astro` | Card markup; story container + toggle button | Modify: remove `<script>`, retarget `.story` transition, drop the clamp, add `id`/`aria-controls` |
+| `src/pages/about.astro` | Page-level inline scripts and global CSS | Modify: add the story reveal script + cursor CSS |
+| `package.json` | Version | Modify (final task) |
+
+No new files. The reveal script joins the two `is:inline` scripts already in `about.astro`.
+
+---
+
+## Task 1: Truncated collapsed state, script consolidated
+
+Replaces the `max-height` clamp with a word-boundary truncation, and moves all story-toggle logic into a pre-paint
+inline script in `about.astro`. After this task, stories truncate cleanly and the toggle expands instantly — **no
+typing yet**. That arrives in Task 2.
+
+**Files:**
+- Modify: `src/components/ExperienceCard.astro`
+- Modify: `src/pages/about.astro`
+
+- [ ] **Step 1: Give the story an id and wire the disclosure**
+
+In `src/components/ExperienceCard.astro`, find:
+
+```astro
+        <div class:list={['story text-[15.5px] leading-[1.65] text-body', !current && 'collapsed']}>
+            <Content/>
+        </div>
+        <button class='story-toggle text-sm font-semibold text-info mt-4'
+                aria-expanded={current ? 'true' : 'false'}>
+            {current ? 'Show less ↑' : 'Read the story ↓'}
+        </button>
+```
+
+Replace with:
+
+```astro
+        <div id={`story-${experience.id}`}
+             class:list={['story text-[15.5px] leading-[1.65] text-body', !current && 'collapsed']}>
+            <Content/>
+        </div>
+        <button class='story-toggle text-sm font-semibold text-info mt-4'
+                aria-expanded={current ? 'true' : 'false'}
+                aria-controls={`story-${experience.id}`}>
+            {current ? 'Show less ↑' : 'Read the story ↓'}
+        </button>
+```
+
+`experience.id` is the collection id, e.g. `10-amek-senior-engineer` — a valid HTML id and unique per card.
+
+Why: the button already claimed `aria-expanded`, but nothing said *what* it expands. Truncation removes the collapsed
+text from the accessibility tree, which makes this a real disclosure widget, so it needs `aria-controls`.
+
+- [ ] **Step 2: Retarget the transition and drop the clamp**
+
+In the same file, find:
+
+```css
+    .story {
+        overflow: hidden;
+        transition: max-height 320ms var(--ease-standard);
+    }
+
+    /* ~3 lines at 15.5px / 1.65 */
+    .story.collapsed {
+        max-height: 77px;
+    }
+```
+
+Replace with:
+
+```css
+    .story {
+        overflow: hidden;
+        /* min-height, not max-height: once truncation replaces the clamp there is no
+           overflow to cap, and a max-height cannot RESERVE space. Task 2 grows this to
+           the story's full height before typing so the page does not shift while the
+           reader reads. */
+        transition: min-height 320ms var(--ease-standard);
+    }
+```
+
+The `collapsed` class stays on the element — the script uses it as a state marker — but it no longer has a CSS rule.
+
+- [ ] **Step 3: Delete the component's script**
+
+In the same file, delete the **entire** `<script>` block starting at line 99 (`// One delegated handler animates every
+story's expand/collapse via max-height.`) through its closing `</script>`. Its logic is re-homed in Step 4.
+
+Do not leave an empty `<script></script>`. Remove the whole block.
+
+- [ ] **Step 4: Add the reveal script to about.astro**
+
+In `src/pages/about.astro`, add this as a **new** `<script is:inline>` block after the existing order-toggle script
+block (the one ending with the `astro:after-swap` listener). Do not merge it into an existing block.
+
+```astro
+<script is:inline>
+    if (!window.__storyRevealBound) {
+        window.__storyRevealBound = true;
+
+        const LINES = 3;   /* collapsed height, matching the 77px clamp this replaces */
+
+        const state = new WeakMap();
+
+        /* Flat character map over the story's text nodes. Walking text nodes (rather than
+           slicing innerHTML) is what keeps <strong> and the bullet list in 09-solo-engineer
+           intact. */
+        const buildState = (story) => {
+            const walker = document.createTreeWalker(story, NodeFilter.SHOW_TEXT);
+            const nodes = [];
+            let offset = 0;
+            let node;
+            while ((node = walker.nextNode())) {
+                const full = node.nodeValue || '';
+                nodes.push({node: node, full: full, start: offset, end: offset + full.length});
+                offset += full.length;
+            }
+            /* Blocks that leave an artefact when emptied: an empty <p> still occupies a
+               line, an empty <li> still paints its bullet via li::before. */
+            const blocks = Array.from(story.querySelectorAll('p, ul, ol, li')).map((el) => {
+                const inside = nodes.filter((n) => el.contains(n.node));
+                return {
+                    el: el,
+                    start: inside.length ? inside[0].start : 0,
+                    end: inside.length ? inside[inside.length - 1].end : 0
+                };
+            });
+            return {nodes: nodes, blocks: blocks, total: offset, cut: offset, cursor: null, raf: 0, typing: false};
+        };
+
+        /* Restore text up to character `upto`; empty everything after. Returns the last
+           node holding revealed text, which is where the cursor goes. */
+        const reveal = (story, upto, ellipsis) => {
+            const s = state.get(story);
+            let tail = null;
+            for (const item of s.nodes) {
+                if (item.end <= upto) {
+                    if (item.node.nodeValue !== item.full) item.node.nodeValue = item.full;
+                    if (item.full.length) tail = item;
+                } else if (item.start >= upto) {
+                    if (item.node.nodeValue !== '') item.node.nodeValue = '';
+                } else {
+                    item.node.nodeValue = item.full.slice(0, upto - item.start);
+                    tail = item;
+                }
+            }
+            for (const b of s.blocks) {
+                b.el.style.display = b.start >= upto && b.end > b.start ? 'none' : '';
+            }
+            if (ellipsis && tail) tail.node.nodeValue = tail.node.nodeValue + '…';
+            return tail;
+        };
+
+        /* Top of the character at `index`, or null if it has no box (collapsed whitespace). */
+        const rectTopAt = (s, index) => {
+            for (const item of s.nodes) {
+                if (index >= item.start && index < item.end) {
+                    const range = document.createRange();
+                    range.setStart(item.node, index - item.start);
+                    range.setEnd(item.node, index - item.start + 1);
+                    const rect = range.getBoundingClientRect();
+                    return rect.height ? rect.top : null;
+                }
+            }
+            return null;
+        };
+
+        /* First character index that falls below `lines` lines. Binary search, not a linear
+           walk: tops increase monotonically down the flow, so this costs ~11 probes per
+           story instead of ~2000. Nothing is mutated during the search, so the layout read
+           stays cached. */
+        const lineBoundary = (story, lines) => {
+            const s = state.get(story);
+            const lineHeight = parseFloat(getComputedStyle(story).lineHeight);
+            if (!lineHeight) return s.total;
+            let firstTop = null;
+            for (let i = 0; i < s.total && firstTop === null; i++) firstTop = rectTopAt(s, i);
+            if (firstTop === null) return s.total;
+            const limit = firstTop + lines * lineHeight - 1;
+            let lo = 0;
+            let hi = s.total;
+            while (lo < hi) {
+                const mid = (lo + hi) >> 1;
+                const top = rectTopAt(s, mid);
+                if (top === null || top <= limit) lo = mid + 1;
+                else hi = mid;
+            }
+            return lo;
+        };
+
+        const truncate = (story) => {
+            const s = state.get(story);
+            reveal(story, s.total); /* measure against the full text */
+            const boundary = lineBoundary(story, LINES);
+            if (boundary >= s.total) {
+                s.cut = s.total;
+                return;
+            }
+            const full = s.nodes.map((n) => n.full).join('');
+            const space = full.slice(0, boundary).lastIndexOf(' ');
+            s.cut = space > 0 ? space : boundary;
+            reveal(story, s.cut, true);
+        };
+
+        const expand = (story, button) => {
+            const s = state.get(story);
+            story.classList.remove('collapsed');
+            button.textContent = 'Show less ↑';
+            button.setAttribute('aria-expanded', 'true');
+            reveal(story, s.total);
+        };
+
+        const collapse = (story, button) => {
+            story.classList.add('collapsed');
+            button.textContent = 'Read the story ↓';
+            button.setAttribute('aria-expanded', 'false');
+            truncate(story);
+        };
+
+        document.addEventListener('click', (event) => {
+            const button = event.target?.closest('.story-toggle');
+            if (!button) return;
+            const story = button.closest('.story-card')?.querySelector('.story');
+            if (!story || !state.has(story)) return;
+            if (story.classList.contains('collapsed')) expand(story, button);
+            else collapse(story, button);
+        });
+
+        /* Runs before paint so the full story never flashes; astro:after-swap covers
+           View Transitions navigations, matching the other scripts on this page. */
+        const initStories = () => {
+            document.querySelectorAll('.story').forEach((story) => {
+                if (!state.has(story)) state.set(story, buildState(story));
+                if (story.classList.contains('collapsed')) truncate(story);
+            });
+        };
+        initStories();
+        document.addEventListener('astro:after-swap', initStories);
+
+        /* The pre-paint pass measures with fallback font metrics, so the boundary is wrong
+           until the web fonts swap in. Re-truncate once they land. The page already
+           reflows on font swap, so this rides along invisibly. Only collapsed stories are
+           re-cut, so a story the reader already expanded is left alone. */
+        if (document.fonts && document.fonts.ready) document.fonts.ready.then(initStories);
+    }
+</script>
+```
+
+Note on the current role: its `.story` has no `collapsed` class, so `initStories` leaves it fully revealed and its
+`state.cut` stays at `total`. That is intended — the spec puts typing-on-load out of scope.
+
+- [ ] **Step 5: Verify the build passes**
+
+Run: `npm run check:build`
+Expected: `[build] Complete!`, no TypeScript errors.
+
+- [ ] **Step 6: Verify in a real browser**
+
+Run `npm run dev -- --host 0.0.0.0` and open `/about`.
+
+Expected observations:
+1. Collapsed cards show roughly three lines ending in `…` — a clean word break, not a mid-word cut.
+2. **No flash of the full story on load.** If you see one, the script is not running pre-paint.
+3. Clicking "Read the story ↓" reveals the full text instantly (no typing yet — correct at this stage).
+4. Clicking "Show less ↑" re-truncates.
+5. Expand `09-solo-engineer` ("Solo Engineer Looking for Opportunities"): its **bullet list renders intact** with no
+   stray bullets while collapsed.
+6. At a narrow width (390px), collapsed cards are still ~3 lines — not 5–6.
+7. The traveling dot still tracks correctly after expanding a card.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/components/ExperienceCard.astro src/pages/about.astro
+git commit -m "Truncating collapsed stories at a word boundary"
+```
+
+---
+
+## Task 2: Height reservation and the typing engine
+
+Adds the reveal animation. Two things carry the quality here: the box grows to full height **before** typing starts, and
+the engine is a frame loop rather than a per-character timer.
+
+**Why a frame loop is not optional:** the longest remainder is 1,796 chars (`06-teknika-backend-lead`, after the
+measured 376-char teaser). At the 6s ceiling that is `dSteady ≈ 3.64ms` — under a quarter of a frame. A `setTimeout`
+per character cannot go below ~4ms and would drift badly. The loop below consumes elapsed time against per-character
+delays and reveals however many characters that buys: ~5 per frame on the longest story, ~1 per frame on the shortest
+(`08-teknika-senior-engineer`, which lands under the ceiling and types at the full 12ms cadence).
+
+**Files:**
+- Modify: `src/pages/about.astro`
+
+- [ ] **Step 1: Add the cursor CSS**
+
+In `src/pages/about.astro`'s `<style is:global>` block, add after the `.order-btn[aria-pressed='true']` rule:
+
+```css
+    /* The cursor is created by script, so it cannot live in ExperienceCard's scoped styles. */
+    .type-cursor {
+        display: inline-block;
+        width: 0.5em;
+        height: 1em;
+        margin-left: 1px;
+        vertical-align: text-bottom;
+        background: var(--accent);
+        animation: type-blink 1s steps(2, start) infinite;
+    }
+
+    .type-cursor.is-done {
+        animation: none;
+        opacity: 0;
+        transition: opacity var(--dur-base) var(--ease-standard);
+    }
+
+    @keyframes type-blink {
+        to {
+            visibility: hidden;
+        }
+    }
+
+    @media (prefers-reduced-motion: reduce) {
+        .type-cursor {
+            animation: none;
+        }
+    }
+```
+
+- [ ] **Step 2: Add the timing constants**
+
+In the reveal script from Task 1, find:
+
+```js
+        const LINES = 3;   /* collapsed height, matching the 77px clamp this replaces */
+```
+
+Insert directly above it:
+
+```js
+        const D_TARGET = 12;       /* ms/char: the steady writing rate we aim for */
+        const CEILING = 6000;      /* ms: hard ceiling on one reveal, no matter how long */
+        const MAX_FRAME_MS = 50;   /* clamp a stalled frame so it cannot dump the story */
+        const GROW_MS = 340;       /* the .story min-height transition is 320ms */
+```
+
+- [ ] **Step 3: Add the engine**
+
+In the same script, insert these three functions directly above `const expand = (story, button) => {`:
+
+```js
+        const finish = (story) => {
+            const s = state.get(story);
+            if (s.raf) cancelAnimationFrame(s.raf);
+            s.raf = 0;
+            s.typing = false;
+            reveal(story, s.total);
+            story.style.minHeight = '';
+            if (s.cursor) {
+                const cursor = s.cursor;
+                s.cursor = null;
+                cursor.classList.add('is-done');
+                setTimeout(() => cursor.remove(), 260);
+            }
+        };
+
+        const placeCursor = (story, upto) => {
+            const s = state.get(story);
+            if (!s.cursor) return;
+            let tail = s.nodes[0];
+            for (const item of s.nodes) if (item.start < upto) tail = item;
+            const parent = tail.node.parentNode;
+            if (parent && s.cursor.previousSibling !== tail.node) {
+                parent.insertBefore(s.cursor, tail.node.nextSibling);
+            }
+        };
+
+        const type = (story) => {
+            const s = state.get(story);
+            /* The reader may have collapsed the card during the grow delay. */
+            if (story.classList.contains('collapsed')) return;
+            const from = s.cut;
+            const N = s.total - from;
+            if (N <= 0) {
+                finish(story);
+                return;
+            }
+
+            /* delay ramps dFast -> dSteady across the first third, then holds constant.
+               Integrating that gives T = 11*N*dSteady/12, hence dSteady = 12T/(11N).
+               Under the ceiling, dSteady resolves to exactly D_TARGET. */
+            const T = Math.min(CEILING, (11 * N * D_TARGET) / 12);
+            const dSteady = (12 * T) / (11 * N);
+            const dFast = dSteady / 2;
+            const delayAt = (i) => dFast + (dSteady - dFast) * Math.min(1, (i / N) * 3);
+
+            s.cursor = document.createElement('span');
+            s.cursor.className = 'type-cursor';
+            s.cursor.setAttribute('aria-hidden', 'true');
+            s.typing = true;
+
+            let revealed = from;
+            let acc = 0;
+            let last = performance.now();
+            const frame = (now) => {
+                acc += Math.min(now - last, MAX_FRAME_MS);
+                last = now;
+                while (revealed < s.total && acc >= delayAt(revealed - from)) {
+                    acc -= delayAt(revealed - from);
+                    revealed++;
+                }
+                reveal(story, revealed);
+                placeCursor(story, revealed);
+                if (revealed >= s.total) {
+                    finish(story);
+                    return;
+                }
+                s.raf = requestAnimationFrame(frame);
+            };
+            s.raf = requestAnimationFrame(frame);
+        };
+```
+
+- [ ] **Step 4: Reserve height, then type**
+
+Replace the `expand` function from Task 1 entirely:
+
+```js
+        const expand = (story, button) => {
+            const s = state.get(story);
+            story.classList.remove('collapsed');
+            button.textContent = 'Show less ↑';
+            button.setAttribute('aria-expanded', 'true');
+
+            /* Measure the full height by briefly revealing everything. This is synchronous
+               and forces one reflow, so the browser never paints the revealed state. */
+            reveal(story, s.total);
+            const fullHeight = story.scrollHeight;
+            reveal(story, s.cut, true);
+
+            /* Reserve the space before typing so nothing below the card shifts while the
+               reader reads. min-height needs an explicit start value — auto will not
+               transition. */
+            story.style.minHeight = story.offsetHeight + 'px';
+            void story.offsetHeight;
+            story.style.minHeight = fullHeight + 'px';
+
+            setTimeout(() => type(story), GROW_MS);
+        };
+```
+
+`setTimeout` rather than `transitionend`: `transitionend` never fires when the height happens not to change, which
+would leave a card stuck showing only its teaser.
+
+- [ ] **Step 5: Cancel typing on collapse**
+
+Replace the `collapse` function from Task 1 entirely:
+
+```js
+        const collapse = (story, button) => {
+            const s = state.get(story);
+            if (s.raf) cancelAnimationFrame(s.raf);
+            s.raf = 0;
+            s.typing = false;
+            if (s.cursor) {
+                s.cursor.remove();
+                s.cursor = null;
+            }
+            story.style.minHeight = '';
+            story.classList.add('collapsed');
+            button.textContent = 'Read the story ↓';
+            button.setAttribute('aria-expanded', 'false');
+            truncate(story);
+        };
+```
+
+- [ ] **Step 6: Verify the build passes**
+
+Run: `npm run check:build`
+Expected: `[build] Complete!`, no TypeScript errors.
+
+- [ ] **Step 7: Verify in a real browser**
+
+Run `npm run dev -- --host 0.0.0.0` and open `/about`.
+
+Expected observations:
+1. Expanding a card grows the box **first**, then text streams in with a visible blinking cursor at the write head.
+2. **Nothing below the card shifts while text types.** If the page pushes down continuously, height reservation failed.
+3. The longest story (`06-teknika-backend-lead`, "Backend Team Lead" at Teknika) takes ~6s. The cursor fades when done.
+4. The bullet list in `09-solo-engineer` types through intact — no stray bullets ahead of the write head.
+5. The traveling dot is still aligned after expansion settles.
+6. Collapsing mid-type stops it cleanly and re-truncates.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add src/pages/about.astro
+git commit -m "Writing out the hidden story with a terminal cursor"
+```
+
+---
+
+## Task 3: Escape hatches
+
+Three ways out, so an impatient reader is never trapped waiting.
+
+**Files:**
+- Modify: `src/pages/about.astro`
+
+- [ ] **Step 1: Skip the animation under reduced motion**
+
+In the reveal script, find the start of `expand`:
+
+```js
+        const expand = (story, button) => {
+            const s = state.get(story);
+            story.classList.remove('collapsed');
+            button.textContent = 'Show less ↑';
+            button.setAttribute('aria-expanded', 'true');
+```
+
+Insert directly after the `aria-expanded` line:
+
+```js
+
+            if (window.matchMedia('(prefers-reduced-motion: reduce)').matches) {
+                reveal(story, s.total);
+                story.style.minHeight = '';
+                return;
+            }
+```
+
+Note: reduced motion still **truncates** when collapsed. Truncation is a disclosure, not an animation — hiding it
+behind a motion preference would leave those readers with no collapsed state at all. Only the animation is skipped.
+
+- [ ] **Step 2: Any click finishes a run in progress**
+
+Replace the click handler from Task 1 entirely:
+
+```js
+        document.addEventListener('click', (event) => {
+            const card = event.target?.closest('.story-card');
+            if (!card) return;
+            const story = card.querySelector('.story');
+            if (!story || !state.has(story)) return;
+
+            /* Mid-run, ANY click on the card finishes immediately — including one on the
+               toggle, which must not collapse a card the reader is waiting to read. */
+            if (state.get(story).typing) {
+                finish(story);
+                return;
+            }
+
+            const button = event.target?.closest('.story-toggle');
+            if (!button) return;
+            if (story.classList.contains('collapsed')) expand(story, button);
+            else collapse(story, button);
+        });
+```
+
+- [ ] **Step 3: Finish if the card scrolls out of view**
+
+In the reveal script, replace `initStories` and its two call sites:
+
+```js
+        /* A card typing off-screen wastes frames and strands the reader with a
+           half-written story when they scroll back. */
+        const offscreenObserver = new IntersectionObserver((entries) => {
+            entries.forEach((entry) => {
+                if (entry.isIntersecting) return;
+                const story = entry.target.querySelector('.story');
+                if (story && state.has(story) && state.get(story).typing) finish(story);
+            });
+        }, {threshold: 0});
+
+        const initStories = () => {
+            document.querySelectorAll('.story').forEach((story) => {
+                if (!state.has(story)) state.set(story, buildState(story));
+                if (story.classList.contains('collapsed')) truncate(story);
+            });
+            document.querySelectorAll('.story-card').forEach((card) => offscreenObserver.observe(card));
+        };
+        initStories();
+        document.addEventListener('astro:after-swap', initStories);
+```
+
+- [ ] **Step 4: Verify the build passes**
+
+Run: `npm run check:build`
+Expected: `[build] Complete!`, no TypeScript errors.
+
+- [ ] **Step 5: Verify in a real browser**
+
+Run `npm run dev -- --host 0.0.0.0` and open `/about`.
+
+Expected observations:
+1. Click a card mid-type: text completes instantly, cursor fades. The card does **not** collapse.
+2. Expand a card and immediately scroll it off-screen; scroll back — it shows the full story, not a half-written one.
+3. In DevTools, emulate `prefers-reduced-motion: reduce`, reload, and expand: text appears instantly, no cursor.
+   Collapsed cards are **still truncated with `…`** — reduced motion does not disable the collapsed state.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/pages/about.astro
+git commit -m "Letting readers escape the story animation"
+```
+
+---
+
+## Task 4: Version bump and pull request
+
+This repo bumps `package.json` per semver in every PR. This adds a user-facing feature: **minor**, `1.2.0` → `1.3.0`.
+
+**Files:**
+- Modify: `package.json`
+
+- [ ] **Step 1: Bump the version**
+
+In `package.json`, change `"version": "1.2.0",` to `"version": "1.3.0",`.
+
+Change **only** that line. If `git diff package.json` shows dependency changes, you have picked up unrelated drift —
+stop and report it.
+
+- [ ] **Step 2: Verify the build passes**
+
+Run: `npm run check:build`
+Expected: `[build] Complete!`, no TypeScript errors.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add package.json
+git commit -m "Bumping version to 1.3.0"
+```
+
+- [ ] **Step 4: Audit the branch**
+
+```bash
+git diff --name-only dev..HEAD
+```
+Expected exactly: the two spec/plan docs, `package.json`, `src/components/ExperienceCard.astro`,
+`src/pages/about.astro`, plus the earlier reading-direction docs. **Nothing under `src/content/`.**
+
+```bash
+git log dev..HEAD --format='%B' | grep -Ei "co-authored-by|claude|anthropic"
+```
+Expected: no matches.
+
+- [ ] **Step 5: Push**
+
+The branch `feat/about-timeline-reading-direction` already exists on the remote with an open draft PR (#20). This work
+extends it. From the **main checkout** (a branch cannot be checked out in two worktrees at once — it is currently on
+`dev`, which is where it should stay):
+
+```bash
+git -C /Users/joeinz/Workspace/personal/Projects/Web/personal-website \
+  branch -f feat/about-timeline-reading-direction worktree-about-timeline
+cd /Users/joeinz/Workspace/personal/Projects/Web/personal-website/.claude/worktrees/about-timeline
+git push origin worktree-about-timeline:feat/about-timeline-reading-direction
+```
+
+Network calls in this environment need the sandbox disabled and may time out — retry up to three times.
+
+- [ ] **Step 6: Update the PR body**
+
+PR #20's description covers only the reading-direction work. Append the typing reveal:
+
+```bash
+gh pr edit 20 --body "$(cat <<'EOF'
+The experience entries read as a story, but the timeline runs newest-first, so reading top-to-bottom meant reading the story backwards. The kicker also said `2019 → Today` while the list ran the other way.
+
+Keeps newest-first as the default and makes the descent deliberate: start years descend down the rail, the kicker matches the order, a "How I got here" sub-header frames the history as a flashback, and each card carries a "Before that" cue.
+
+Adds a `Latest first | Story order` toggle for readers who want the story in order. It persists in localStorage and flips direction text via a single CSS class, so no JavaScript rewrites strings.
+
+Also reworks the "Read the story" expansion. Collapsed cards now truncate at a word boundary instead of being clipped mid-word, and expanding writes the hidden text out with a terminal cursor. The box grows to its full height before typing so nothing below shifts while you read. Readers can escape at any time: clicking finishes it, scrolling away finishes it, and reduced-motion skips it entirely.
+
+Verified in a real browser at both widths: the traveling dot stays synced in both orders (zero drift), the leading card's cue is suppressed either way, and the stored order applies before first paint.
+
+Design: `docs/superpowers/specs/2026-07-16-about-timeline-reading-direction-design.md`, `docs/superpowers/specs/2026-07-17-story-typing-reveal-design.md`
+EOF
+)"
+```
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+
+| Spec requirement | Task |
+|---|---|
+| Word-boundary truncation replaces the 77px clamp | 1 (Steps 2, 4) |
+| Teaser matches the collapsed height at any width | 1 (`lineBoundary`, measured — supersedes the spec's fixed 200/120 budgets, which measurement disproved; spec amended) |
+| Boundary survives web-font swap | 1 (`document.fonts.ready` re-truncate) |
+| Pre-paint truncation, no flash | 1 (`initStories()` called immediately in an `is:inline` script) |
+| `TreeWalker` preserves `<strong>` / `<ul>` | 1 (`buildState`) |
+| `aria-controls` completes the disclosure | 1 (Step 1) |
+| Grow box first, then type | 2 (Step 4) |
+| `min-height` reservation with explicit start value | 1 (Step 2 CSS), 2 (Step 4) |
+| rAF accumulator engine | 2 (Step 3, `type`) |
+| Curve: `dFast = dSteady/2`, ramp over first third | 2 (Step 3, `delayAt`) |
+| `T = min(6000, 11·N·D_TARGET/12)`, `dSteady = 12T/(11N)` | 2 (Step 3) |
+| Cursor at write head, blinks, fades on completion | 2 (Steps 1, 3) |
+| Click to finish | 3 (Step 2) |
+| `IntersectionObserver` auto-finish | 3 (Step 3) |
+| `prefers-reduced-motion` skips | 3 (Step 1) |
+| Current role does not type on load | 1 (no `collapsed` class → untouched; noted after Step 4) |
+| Collapse stays instant | 2 (Step 5) |
+
+No gaps.
+
+**Placeholder scan:** none. Every step names exact files and shows the actual code.
+
+**Type consistency:** `state` is a `WeakMap` keyed by the `.story` element, holding `{nodes, blocks, total, cut,
+cursor, raf, typing}` — defined in Task 1 `buildState`, and every later reference (`s.cut`, `s.total`, `s.typing`,
+`s.raf`, `s.cursor`) matches. `reveal(story, upto, ellipsis)` keeps its signature across Tasks 1–3. `finish`,
+`placeCursor`, `type` are defined in Task 2 and consumed in Task 3. `.type-cursor` / `.is-done` are defined in Task 2
+Step 1 and used in Task 2 Step 3.
+
+**Ordering dependency:** Task 2 replaces `expand`/`collapse` wholesale from Task 1; Task 3 replaces the click handler
+and `initStories` wholesale from Task 1. Execute in order.

--- a/docs/superpowers/specs/2026-07-16-about-timeline-reading-direction-design.md
+++ b/docs/superpowers/specs/2026-07-16-about-timeline-reading-direction-design.md
@@ -1,0 +1,143 @@
+# About Timeline: Reading Direction — Design
+
+**Date:** 2026-07-16
+**Status:** Approved, not yet implemented
+
+## Problem
+
+The ten entries in `src/content/experiences/` are written as narrative prose — chapters of a story. The About page
+renders them newest-first, so reading top-to-bottom means reading the story backwards.
+
+This is not a subjective impression; the arc is literal:
+
+- `01-dubai-backend.md` opens with "My professional journey began right after university" — a story's first line.
+- `10-amek-senior-engineer.md` closes with "This chapter is still being written" — a story's last line.
+
+Top-to-bottom, the reader gets the ending first and the opening last.
+
+Two supporting problems surfaced during investigation:
+
+1. **The page contradicts itself.** The kicker in `src/pages/about.astro` reads `2019 → Today · 10 roles` while the
+   list beneath it runs Today → 2019. The label promises forward motion the order does not deliver.
+2. **The story is opt-in and fragmented.** Every non-current card is clamped to ~3 lines behind a "Read the story ↓"
+   toggle, so continuous narrative reading is not currently possible. (Out of scope here — see below.)
+
+## Constraints
+
+- **Newest-first stays the default.** Every visitor lands on newest-first. This serves recruiters, who want the
+  current role first, and is non-negotiable.
+- **A reader-controlled toggle to chronological order is permitted** as an opt-in layer.
+- **Content copy may change**, with one hard exception below.
+
+### Hard constraint: no directional connectives in markdown
+
+Because a toggle can flip the order, any directional language baked into the markdown bodies ("Before that…",
+"Earlier…") becomes wrong the moment a reader flips to story order. **Directional language must live in the component**,
+where it can flip with the order. Copy being fair game does not extend to connectives.
+
+## Approach
+
+Phased. Phase 1 is framing and helps 100% of visitors with zero interaction. Phase 2 is the toggle and helps only
+those who find it. Phase 1 ships first and stands alone: if Phase 2 never ships, the page still reads correctly.
+
+## Phase 1 — Framing (no JavaScript)
+
+### 1. Years on the rail
+
+Each entry's rail column gains a small muted start year above its dot, descending 2026 → 2019. This is the
+load-bearing cue: descending numbers make direction unmistakable before a single word is read.
+
+Desktop only (`hidden md:block`). The mobile gutter is 28px and the card meta line already carries dates.
+
+**Geometry (measured, not assumed):** "2026" at ~11px tabular Inter is ~26px wide and fits the **existing** 48px md
+gutter. The gutter does **not** need widening. Therefore `about.astro`'s hardcoded rail geometry — line
+`left-[13px] md:left-[23px]`, marker `left-[7px] md:left-[17px]`, and `DOT_CENTER_OFFSET = 55` — is **unchanged**.
+
+The year must sit inside the rail column's existing 48px of top padding so the dot does not move:
+
+| Breakpoint | Rail column padding | Year | Gap | Dot top | Dot center |
+|---|---|---|---|---|---|
+| mobile (year hidden) | `pt-12` = 48px | — | — | 48px | 55px |
+| md (year shown) | `pt-6` = 24px | ~14px | 10px | 48px | 55px |
+
+Rail column classes become `pt-12 md:pt-6`; the year element is `hidden md:block mb-[10px]` with tight leading.
+`DOT_CENTER_OFFSET` stays 55 at both breakpoints, so the traveling dot stays synced.
+
+**Year source:** first four characters of `startDate` (the role's start year).
+
+**Repeated years are accepted, deliberately.** Start years are 2026, 2025, 2025, 2024, 2023, 2023, 2023, 2022, 2021,
+2019 — three roles began in 2023. The rail will show `2023` three times. This is kept rather than suppressed because:
+
+- Suppressing repeats cannot survive the Phase 2 reversal without JS (which occurrence is "first" flips with order).
+- The stutter is honest signal: three roles in 2023 shows progression velocity at Teknika.
+- Non-increasing years still read unambiguously as a descent.
+
+### 2. Kicker corrected
+
+In `src/pages/about.astro`, `2019 → Today · {n} roles` becomes `Today → 2019 · {n} roles`, so the label matches the
+list. Phase 2 makes this direction-aware.
+
+### 3. Flashback frame
+
+A `How I got here` sub-header is inserted after the first entry, turning everything below it into an explicit
+retrospective. Backwards reading becomes intentional rather than broken.
+
+It renders in the **content column**, not the rail, so the rail runs unbroken from first dot to last. It is a sibling
+of the `.timeline-entry` nodes, which matters for Phase 2 (see below).
+
+Entries are **not** structurally split into `[current, ...rest]`. All ten render in the existing loop. The "Now" hero
+treatment largely exists already — `ExperienceCard` renders a `Current` badge and the current role's story is expanded
+by default — so this reduces to emphasis on the existing card, not new structure.
+
+### 4. Direction cue
+
+Non-leading cards get a "Before that" chip. It is rendered CSS-driven, with both variants present:
+
+```html
+<span class='cue-back'>Before that</span><span class='cue-forward'>Then</span>
+```
+
+`.cue-forward` is hidden by default; `.order-story .cue-back` hides and `.order-story .cue-forward` shows. Phase 2
+then only toggles one class — no JS rewriting strings.
+
+The cue is hidden on `.timeline-entry:first-child`. This is self-correcting: the leading card suppresses its own cue
+in **either** order, with no position logic and no JS.
+
+## Phase 2 — Toggle
+
+A `Latest first | Story order` segmented control near the section header, defaulting to `Latest first`. The choice
+persists in `localStorage`, following the existing theme-persistence pattern, and re-applies on
+`astro:after-swap` / `astro:page-load` with window guards per the repo's View Transitions conventions.
+
+Selecting `Story order`:
+
+1. Adds `.order-story` to `#experienceTimeline` — flips the cue chips via CSS (Phase 1 already built this).
+2. **Reverses the `.timeline-entry` DOM nodes.** Must move actual nodes, selecting `.timeline-entry` only so the
+   `How I got here` sub-header is not swept into the reversal.
+3. Hides the `How I got here` sub-header via `.order-story` — the flashback frame is meaningless in chronological
+   order, where the current role is last.
+4. Flips the kicker to `2019 → Today`.
+5. Re-runs the rail's `update()`.
+
+**Reversal must move DOM nodes, not use CSS `column-reverse`.** The rail script pairs `querySelectorAll` (DOM order)
+with `offsetTop`; `column-reverse` would desync visual and DOM order and silently break the traveling-dot math.
+
+## Out of scope
+
+- **The 3-line clamp** truncates prose mid-sentence, which is itself anti-story. A curated one-line teaser per entry
+  in frontmatter would make scan mode read as chapter blurbs. Real improvement, separate concern from direction; this
+  is the next thing to fix.
+- **Chapter counters** ("Chapter 10 of 10") — considered and dropped as gimmicky given the rail years already carry
+  direction.
+- **Reordering the default** — explicitly ruled out by the constraints.
+
+## Verification
+
+No test framework is configured; `npm run check:build` is the primary gate.
+
+1. `npm run check:build` passes.
+2. Dev server pass: the traveling dot tracks correctly at mobile and desktop widths.
+3. Rail years render descending on desktop, hidden on mobile.
+4. The leading card shows no cue chip; all others do.
+5. Phase 2 only: flipping to story order reverses entries, hides the sub-header, flips cues and kicker, and leaves
+   the traveling dot synced. Selection survives a reload and a View Transitions navigation.

--- a/docs/superpowers/specs/2026-07-17-mobile-header-design.md
+++ b/docs/superpowers/specs/2026-07-17-mobile-header-design.md
@@ -1,0 +1,96 @@
+# Mobile Header + Footer Socials — Design
+
+**Date:** 2026-07-17
+**Status:** Approved (via visual companion), not yet implemented
+
+## Problem
+
+The site header (`src/layouts/components/Header.astro`) is a single non-wrapping flex row — logo, nav links, two
+social icons, and a Light/Dark text toggle — with **no mobile layout**. Below ~554px of content width it overflows;
+at 390px the theme toggle sits off-screen at x=527, forcing horizontal scroll on every page. (This is separate from
+the tag-line overflow already fixed in `885154b`; with the header hidden, the page fits 390px exactly.)
+
+## Decisions (confirmed via mockups)
+
+**Approach A — slide-down menu**, below the `md` (768px) breakpoint. Desktop (≥768px) is unchanged.
+
+| Aspect | Decision |
+|---|---|
+| Mobile bar layout | logo (left) · centered group (right) · hamburger — where the centered group is **GitHub · LinkedIn · theme switch** |
+| Nav links on mobile | move into a slide-down panel opened by the hamburger |
+| Theme switch | keep its two-segment pill; **text → SVG sun + full moon**; **icon + text on desktop, icon-only on mobile** |
+| Social icons | GitHub + LinkedIn, real SVG marks, monochrome (ink light / cream dark) — as the header already ships them |
+| Footer | add the same GitHub + LinkedIn icons, **centered**, at all widths |
+| Scope | header centered-group is **mobile-only**; footer socials apply at **all widths** |
+
+## Architecture
+
+### Single responsive right-group (no duplication)
+
+The mobile "centered" and desktop "right" positions are the **same element**, repositioned with flex auto-margins —
+avoiding a duplicated theme toggle (and the duplicate-id hazard). Bar structure:
+
+```
+<nav class="flex items-center gap-4">
+  <a logo>                                   shrink-0, always
+  <div nav-links   class="hidden md:flex md:mx-auto">   desktop only, centered
+  <div right-group class="mx-auto md:mx-0">  socials + switch: centered on mobile, pushed right on desktop
+  <button hamburger class="md:hidden">       mobile only
+</nav>
+```
+
+- **Mobile** (nav-links hidden, hamburger shown): `logo · [right-group mx-auto → centered] · hamburger`.
+- **Desktop** (hamburger hidden): nav-links `md:mx-auto` takes the auto-space, pushing the right-group to the far
+  right — reproducing today's `justify-between` layout exactly.
+
+### Theme switch
+
+One instance, class-based (`.theme-toggle`) — the existing `#themeToggle` script already uses
+`querySelectorAll`/`closest`, so switching id→class is safe and future-proofs multiple instances. Each segment gets an
+inline SVG (sun / full moon) plus a label span marked `hidden md:inline` (icon-only below md, icon+text at md+). The
+full moon is a `currentColor` disc with three low-opacity craters so it never reads as a plain dot. Segment padding
+tightens on mobile.
+
+### Slide-down panel
+
+A block below `<nav>` inside `<header>`, `md:hidden`, containing the four nav links stacked vertically. Toggled by the
+hamburger. Since `<header>` is `sticky top-0`, the panel pushes content down (slide), not an overlay.
+
+**Accessibility (required):**
+- Hamburger: `aria-expanded`, `aria-controls="mobileMenu"`, `aria-label`. Panel: `id="mobileMenu"`.
+- Open moves focus to the first link; close returns focus to the hamburger.
+- `Escape` closes; a click outside the header closes.
+- Closes on navigation (`astro:page-load`) so it's never left open after a View-Transitions route change.
+- Respects `prefers-reduced-motion` (no slide animation; instant show/hide).
+
+### New component
+
+`SocialLinks.astro` — renders the GitHub + LinkedIn `<a>` links with the existing ink/cream `<Image>` icon pairs
+(from `@src/assets/img/*.svg`, using `GITHUB_ACCOUNT` / `LINKEDIN_ACCOUNT` from `consts`). Reused in the header
+right-group and the footer, so the markup lives in one place. A `gap` / size prop keeps header vs footer sizing tidy.
+
+### Footer
+
+`src/layouts/components/Footer.astro` becomes a three-part row: Byline (left) · `SocialLinks` (center) · copyright
+(right). It already uses `flex-col sm:flex-row items-center justify-between`; the centered socials slot in the middle
+and stack cleanly on mobile.
+
+## Out of scope
+
+- Desktop header appearance — unchanged.
+- The tag-line / grid overflow — already fixed (`885154b`).
+- Any nav content change (same four links: Home, About, Projects, Posts).
+
+## Verification
+
+No test framework; `npm run check:build` plus a real-browser pass (this branch has repeatedly shipped bugs only a live
+browser caught — `dist/` inspection is insufficient).
+
+1. `npm run check:build` passes.
+2. At 390px and 360px: **no horizontal scroll** on `/`, `/about`, `/projects`, `/posts`. `document.scrollWidth <= innerWidth`.
+3. Mobile bar: logo left, GitHub·LinkedIn·switch centered, hamburger right. Switch is icon-only.
+4. Hamburger opens/closes the panel; Esc, outside-click, and navigation all close it; focus moves in and returns.
+5. Desktop (≥768px) header is visually identical to before — switch shows icon **+** text, no hamburger, no panel.
+6. Theme toggle still flips theme + persists, in both mobile and desktop forms; sun shows in light, full moon in dark.
+7. Footer shows centered GitHub + LinkedIn at desktop and mobile, both themes.
+8. Full moon renders as a craters disc, not a plain dot; icons recolor correctly in light and dark.

--- a/docs/superpowers/specs/2026-07-17-story-typing-reveal-design.md
+++ b/docs/superpowers/specs/2026-07-17-story-typing-reveal-design.md
@@ -1,0 +1,174 @@
+# Story Typing Reveal — Design
+
+**Date:** 2026-07-17
+**Status:** Approved, not yet implemented
+**Builds on:** `2026-07-16-about-timeline-reading-direction-design.md`
+
+## Goal
+
+When a reader clicks "Read the story ↓" on an About page experience card, the previously hidden part of the story is
+written out with a terminal-style cursor, rather than appearing instantly.
+
+## The central constraint: this streams, it does not type
+
+Stories are long. Measured from `src/content/experiences/*.md`:
+
+| story | chars | @12ms/char (classic typewriter) |
+|---|---|---|
+| 06-teknika-backend-lead | 2,172 | 26.1s |
+| 07-teknika-dev-manager | 2,054 | 24.6s |
+| 10-amek-senior-engineer | 1,362 | 16.3s |
+| 08-teknika-senior-engineer | 831 | 10.0s |
+
+A typewriter **gates reading** — the reader cannot read faster than the animation. A 26-second gate is unacceptable,
+so the total is capped at ~3s (see Decisions).
+
+The consequence must be stated plainly, because it shapes every other choice:
+
+- Longest remainder ≈ 1,972 chars (2,172 minus the ~200-char teaser). In 3s that is ~660 chars/sec.
+- At 60fps that is **~11 characters per frame**.
+- A classic typewriter cadence is 30–60 chars/sec. People read at ~25 chars/sec.
+
+So this effect reads as **fast terminal output streaming in** (like `cat`-ing a file), not as someone typing. The
+cursor is what sells it as "being written". This was accepted knowingly. Two things follow:
+
+1. **Per-character `setTimeout` is impossible.** The engine must be a frame loop that reveals a batch per frame.
+2. Nobody should expect a slow, deliberate keystroke rhythm on the long stories. The short ones (~631-char remainder,
+   ~210 chars/sec) are the only ones where individual characters are perceptible.
+
+## Decisions
+
+| Question | Decision |
+|---|---|
+| Where does typing start? | Replace the 77px clamp with a word-boundary truncation, so the boundary is a known character index. No layout measurement of the cut. |
+| Total duration | Capped: `min(3000ms, N × 6ms)`. Speed adapts to length; every card feels the same. Short remainders finish early rather than being dragged out to fill 3s. |
+| Speed curve | Fast, then settle to a steady pace. Decelerates to a constant rate, never to a crawl. |
+| Escape hatches | All three: click to finish instantly; `prefers-reduced-motion` skips entirely; auto-finish if scrolled out of view. |
+| Mobile truncation | Responsive: ~200 chars desktop, ~120 chars mobile. |
+| Screen readers | Collapsed content leaves the accessibility tree. Disclosure pattern completed with `aria-controls`. |
+
+### Why responsive truncation
+
+Today's `max-height: 77px` yields ~3 lines at *any* width. A fixed ~200 chars is ~3 lines on desktop but ~5–6 lines
+on mobile, which would visibly grow mobile cards. A responsive count preserves the existing ~3-line intent at both
+breakpoints.
+
+### Why the screen-reader change is acceptable
+
+Today `overflow: hidden` clips the story visually but leaves it in the accessibility tree — a screen reader reads the
+entire story while the card *looks* collapsed, and the toggle's `aria-expanded` state is a lie. Truncating removes the
+text until expand, which is the standard disclosure behavior and matches `aria-expanded`. This is a fix, not a
+regression. The toggle gains `aria-controls` pointing at the story region to complete the pattern.
+
+## Architecture
+
+### 1. Collapsed state
+
+An `is:inline` script runs **pre-paint** (the pattern already established by the theme setup in `BaseLayout.astro` and
+the order toggle in `about.astro`) and, for each collapsed story:
+
+1. Walks text nodes with a `TreeWalker`, building a flat character map `[{node, start, end, text}]`.
+2. Caches each node's full text.
+3. Truncates at the last word boundary at or before the budget (200 desktop / 120 mobile), appends `…`, and empties
+   the text nodes past the cut.
+
+Running pre-paint avoids a flash of the full story. The `TreeWalker` approach preserves `<strong>` and `<ul>`/`<li>`
+markup — only `09-solo-engineer.md` has a list, but it must survive.
+
+The existing `.story.collapsed { max-height: 77px }` rule is removed; truncation replaces it.
+
+### 2. Expand sequence
+
+Order matters, and this is the part that most affects perceived quality:
+
+1. **Grow the box to full height first**, reusing the existing 320ms `max-height` transition. Full height is obtained
+   by measuring an offscreen clone carrying the full text.
+2. **Then** start typing into the settled box.
+
+Text fills a pre-sized area instead of pushing the page down for three seconds. Two consequences: no continuous layout
+shift while the reader is reading, and the timeline rail re-syncs **once** after expansion rather than every frame for
+3s. (The page has a `ResizeObserver` on `documentElement` driving the traveling dot; letting the card grow for 3s
+would churn it continuously.)
+
+### 3. The engine
+
+A `requestAnimationFrame` loop with a delay accumulator:
+
+```
+acc += dt
+while (revealed < N && acc >= delayAt(revealed)) { acc -= delayAt(revealed); revealed++ }
+```
+
+This reveals however many characters the elapsed time buys — 1 on short stories, ~11 on the longest — and is
+frame-rate independent. Revealing means restoring `textContent` on the mapped text nodes up to `revealed`.
+
+### 4. The speed curve
+
+Per-character delay ramps linearly from `dFast` to `dSteady` across the first third of characters, then holds
+constant:
+
+```
+p     = i / N
+ramp  = min(1, p / (1/3))
+delay = dFast + (dSteady - dFast) * ramp
+```
+
+With `dFast = dSteady / 3`, integrating gives total `T = 8·N·dSteady / 9`, therefore:
+
+```
+dSteady = 9T / (8N)
+dFast   = dSteady / 3
+```
+
+Worked example — 1,972-char remainder, `T = 3000ms`: `dSteady ≈ 1.71ms`, `dFast ≈ 0.57ms`. Both far below one frame,
+which is exactly why the accumulator loop above is required.
+
+### 5. Cursor
+
+A single block `<span>` at the write head, moved to follow the current text node, blinking via a CSS animation using
+`--accent`. It fades out on completion — ten cards each left with a permanently blinking cursor would be noise.
+
+### 6. Escape hatches
+
+- **Click** anywhere on the card (or the toggle again) finishes instantly: restore all text, remove cursor.
+- **`IntersectionObserver`** — if the card leaves the viewport mid-run, snap to full text.
+- **`prefers-reduced-motion`** — no typing and no truncation; stories render in full, and the toggle expands
+  instantly. This is non-negotiable and matches the repo's existing motion policy (`global.css:100`).
+
+## Design system constraints
+
+- Motion tokens: `--ease-standard: cubic-bezier(.22,.61,.36,1)`, `--dur-fast: 120ms`, `--dur-base: 220ms`,
+  `--dur-slow: 420ms`. The cursor blink and fade use these; the typing curve is computed in JS (no token maps to it).
+- Cursor colour: `--accent`. Never hard-code palette values.
+- Reuse the existing `.story-toggle` button and `.story` container; do not introduce a parallel component.
+
+## Known limitations, accepted
+
+- **Streaming, not typing** on long stories. See above. Inherent to the 3s cap.
+- **Screen readers during the run.** Text is inserted progressively, so a screen reader that starts reading the
+  instant the toggle is activated could encounter partial text. Bounded at 3s, and screen-reader reading is slower
+  than 660 chars/sec, so the text lands well before it is reached. Reduced-motion users skip the animation entirely.
+- **Find-in-page** will not match text that has not been typed yet, and will not match collapsed text at all
+  (it is not in the DOM). Same as any disclosure widget.
+
+## Out of scope
+
+- Typing on the current role's card, which is expanded by default on load. It renders in full, no animation.
+- Reverse animation on collapse ("Show less ↑") — collapse stays instant.
+- Any change to the reading-order toggle, the rail, or `DOT_CENTER_OFFSET`.
+
+## Verification
+
+No test framework; `npm run check:build` is the gate, plus a live browser pass (the previous feature shipped a bug
+that only a real browser caught — `dist/` inspection is not sufficient).
+
+1. `npm run check:build` passes.
+2. Collapsed cards show ~3 lines ending in `…` at desktop and mobile widths.
+3. Expanding: box grows first, then text streams in with a visible cursor; total ≈3s on the longest story, less on
+   short ones.
+4. No layout shift below the card while typing (box is pre-sized).
+5. The traveling dot stays synced after expansion.
+6. Clicking mid-run finishes instantly. Scrolling away mid-run snaps to full text.
+7. Under `prefers-reduced-motion`, stories are never truncated and expansion is instant.
+8. `09-solo-engineer.md`'s bullet list survives truncation and typing intact.
+9. The toggle's `aria-expanded` matches reality, and `aria-controls` resolves to the story region.

--- a/docs/superpowers/specs/2026-07-17-story-typing-reveal-design.md
+++ b/docs/superpowers/specs/2026-07-17-story-typing-reveal-design.md
@@ -21,28 +21,49 @@ Stories are long. Measured from `src/content/experiences/*.md`:
 | 08-teknika-senior-engineer | 831 | 10.0s |
 
 A typewriter **gates reading** — the reader cannot read faster than the animation. A 26-second gate is unacceptable,
-so the total is capped at ~3s (see Decisions).
+so the total is ceilinged at 6s (see Decisions).
 
 The consequence must be stated plainly, because it shapes every other choice:
 
-- Longest remainder ≈ 1,972 chars (2,172 minus the ~200-char teaser). In 3s that is ~660 chars/sec.
-- At 60fps that is **~11 characters per frame**.
+- Longest remainder ≈ 1,972 chars (2,172 minus the ~200-char teaser). In 6s that is ~330 chars/sec.
+- At 60fps that is **~5 characters per frame**.
 - A classic typewriter cadence is 30–60 chars/sec. People read at ~25 chars/sec.
 
-So this effect reads as **fast terminal output streaming in** (like `cat`-ing a file), not as someone typing. The
-cursor is what sells it as "being written". This was accepted knowingly. Two things follow:
+So on the **long** stories the effect still reads as fast terminal output streaming in, not as someone typing. 1,972
+characters cannot be written deliberately in six seconds; no parameter choice escapes that. The cursor is what sells
+it as "being written". Two things follow:
 
 1. **Per-character `setTimeout` is impossible.** The engine must be a frame loop that reveals a batch per frame.
-2. Nobody should expect a slow, deliberate keystroke rhythm on the long stories. The short ones (~631-char remainder,
-   ~210 chars/sec) are the only ones where individual characters are perceptible.
+2. The **short** stories are where the writing feel actually lands: a 631-char remainder runs at ~96 chars/sec
+   (~1.5 chars/frame), which reads as brisk writing rather than a dump.
+
+### What the ceiling means today
+
+With current content, every story hits the 6s ceiling:
+
+| story | remainder | wants @12ms/char | actual | steady rate |
+|---|---|---|---|---|
+| 08-teknika-senior-engineer | 631 | 6.9s | 6.0s | ~96 chars/s — reads as writing |
+| 01-dubai-backend | 686 | 7.5s | 6.0s | ~114 chars/s |
+| 05-teknika-software-engineer | 897 | 9.9s | 6.0s | ~150 chars/s |
+| 02-assistt-full-stack | 1,019 | 11.2s | 6.0s | ~170 chars/s |
+| 09-solo-engineer | 1,153 | 12.7s | 6.0s | ~192 chars/s |
+| 10-amek-senior-engineer | 1,162 | 12.8s | 6.0s | ~194 chars/s |
+| 03-retavo-back-lead | 1,196 | 13.2s | 6.0s | ~199 chars/s |
+| 07-teknika-dev-manager | 1,854 | 20.4s | 6.0s | ~309 chars/s |
+| 06-teknika-backend-lead | 1,972 | 21.7s | 6.0s | ~329 chars/s — streams |
+
+The dynamic formula is still correct to implement, and it is not dead code: a shorter role added later (say 300
+chars) resolves to ~3.3s at the true 12ms/char writing cadence instead of being padded out to 6s. It simply does not
+produce visible variation across *today's* ten stories, all of which are long enough to be compressed.
 
 ## Decisions
 
 | Question | Decision |
 |---|---|
 | Where does typing start? | Replace the 77px clamp with a word-boundary truncation, so the boundary is a known character index. No layout measurement of the cut. |
-| Total duration | Capped: `min(3000ms, N × 6ms)`. Speed adapts to length; every card feels the same. Short remainders finish early rather than being dragged out to fill 3s. |
-| Speed curve | Fast, then settle to a steady pace. Decelerates to a constant rate, never to a crawl. |
+| Total duration | Dynamic, ceilinged at 6s. Aim for a 12ms/char steady writing rate; compress only when that would exceed 6s. The priority is the *feel of writing*, not finishing fast. |
+| Speed curve | Fast, then settle to a steady pace. The opening burst is 2× the steady rate — quicker, but not a blur. Decelerates to a constant rate, never to a crawl. |
 | Escape hatches | All three: click to finish instantly; `prefers-reduced-motion` skips entirely; auto-finish if scrolled out of view. |
 | Mobile truncation | Responsive: ~200 chars desktop, ~120 chars mobile. |
 | Screen readers | Collapsed content leaves the accessibility tree. Disclosure pattern completed with `aria-controls`. |
@@ -129,15 +150,37 @@ ramp  = min(1, p / (1/3))
 delay = dFast + (dSteady - dFast) * ramp
 ```
 
-With `dFast = dSteady / 3`, integrating gives total `T = 8·N·dSteady / 9`, therefore:
+The opening burst is **2×** the steady rate (`dFast = dSteady / 2`). It was 3× in an earlier draft; that was softened
+deliberately, because a 3× burst on a long story reaches ~15 chars/frame — a blur, which is the opposite of the feel
+of writing.
+
+Integrating the ramp plus the constant tail:
 
 ```
-dSteady = 9T / (8N)
-dFast   = dSteady / 3
+T = N·(dFast + dSteady)/6  +  2N·dSteady/3
 ```
 
-Worked example — 1,972-char remainder, `T = 3000ms`: `dSteady ≈ 1.71ms`, `dFast ≈ 0.57ms`. Both far below one frame,
-which is exactly why the accumulator loop above is required.
+Substituting `dFast = dSteady/2` gives `T = 11·N·dSteady / 12`, therefore:
+
+```
+D_TARGET = 12ms          // desired steady writing rate
+CEILING  = 6000ms
+
+T       = min(CEILING, 11·N·D_TARGET/12)
+dSteady = 12T / (11N)
+dFast   = dSteady / 2
+```
+
+This is self-consistent: when a story lands under the ceiling, `dSteady` resolves to exactly `D_TARGET`.
+
+Worked examples:
+
+- **1,972-char remainder** — `T` clamps to 6000ms; `dSteady ≈ 3.32ms`, `dFast ≈ 1.66ms`. Both far below one frame,
+  which is exactly why the accumulator loop is required.
+- **631-char remainder** — `T` clamps to 6000ms; `dSteady ≈ 10.37ms`, `dFast ≈ 5.19ms`. Roughly one character every
+  frame or two: the writing feel.
+- **300-char remainder (hypothetical future entry)** — `T = 3300ms` (under the ceiling); `dSteady = 12ms` exactly,
+  `dFast = 6ms`.
 
 ### 5. Cursor
 
@@ -160,10 +203,11 @@ A single block `<span>` at the write head, moved to follow the current text node
 
 ## Known limitations, accepted
 
-- **Streaming, not typing** on long stories. See above. Inherent to the 3s cap.
+- **Streaming, not typing** on the long stories. See above. Inherent to the 6s ceiling; no parameter choice escapes it.
 - **Screen readers during the run.** Text is inserted progressively, so a screen reader that starts reading the
-  instant the toggle is activated could encounter partial text. Bounded at 3s, and screen-reader reading is slower
-  than 660 chars/sec, so the text lands well before it is reached. Reduced-motion users skip the animation entirely.
+  instant the toggle is activated could encounter partial text. Bounded at 6s, and screen-reader reading is far slower
+  than even the slowest steady rate here (~96 chars/sec), so the text lands well before it is reached. Reduced-motion
+  users skip the animation entirely.
 - **Find-in-page** will not match text that has not been typed yet, and will not match collapsed text at all
   (it is not in the DOM). Same as any disclosure widget.
 

--- a/docs/superpowers/specs/2026-07-17-story-typing-reveal-design.md
+++ b/docs/superpowers/specs/2026-07-17-story-typing-reveal-design.md
@@ -96,6 +96,27 @@ The measurement is a binary search (~11 probes per story, since line tops increa
 linear walk over ~2,000 characters. It re-runs on `document.fonts.ready`, because the pre-paint pass measures with
 fallback font metrics and would otherwise cut at the wrong place once the web font swaps in.
 
+### Line breaking is not greedy — `text-wrap: pretty`
+
+`src/styles/global.css:118` sets `p { text-wrap: pretty }`, part of the design system's original tokens. `pretty`
+rebalances a paragraph's line breaks across its **whole content** to avoid orphans. The consequence is easy to miss
+and fatal to a naive implementation:
+
+> **A boundary measured against the full story stops being true the moment you cut the text**, because the shorter
+> paragraph re-wraps differently. The measurement invalidates itself.
+
+This was not theoretical. Measured in a real browser after the first implementation pass, **two of nine collapsed
+cards rendered 4 lines instead of 3** from exactly this effect — and re-running the measurement with fonts fully
+loaded did not fix it, which is what ruled out the font-metric explanation.
+
+`truncate` therefore applies its cut, then **re-measures what it actually rendered** and tightens until it fits,
+capped at 4 passes. It converges in 1-2. Two supporting details:
+
+- The re-measure must be bounded to the current cut. Nodes past the cut hold `''`, and a `Range.setStart` beyond a
+  node's length throws `IndexSizeError`.
+- Setting `text-wrap: auto` on the story would also "fix" it and is **rejected**: it is a deliberate typographic
+  choice of the design system, and the brief was to respect the design system.
+
 ### Why the screen-reader change is acceptable
 
 Today `overflow: hidden` clips the story visually but leaves it in the accessibility tree — a screen reader reads the

--- a/docs/superpowers/specs/2026-07-17-story-typing-reveal-design.md
+++ b/docs/superpowers/specs/2026-07-17-story-typing-reveal-design.md
@@ -25,37 +25,41 @@ so the total is ceilinged at 6s (see Decisions).
 
 The consequence must be stated plainly, because it shapes every other choice:
 
-- Longest remainder ≈ 1,972 chars (2,172 minus the ~200-char teaser). In 6s that is ~330 chars/sec.
+- Longest remainder = 1,796 chars (2,172 minus the measured 376-char teaser). In 6s that is ~300 chars/sec.
 - At 60fps that is **~5 characters per frame**.
 - A classic typewriter cadence is 30–60 chars/sec. People read at ~25 chars/sec.
 
-So on the **long** stories the effect still reads as fast terminal output streaming in, not as someone typing. 1,972
-characters cannot be written deliberately in six seconds; no parameter choice escapes that. The cursor is what sells
-it as "being written". Two things follow:
+So on the **two longest** stories the effect still reads as fast terminal output streaming in, not as someone typing.
+1,796 characters cannot be written deliberately in six seconds; no parameter choice escapes that. The cursor is what
+sells it as "being written". Two things follow:
 
-1. **Per-character `setTimeout` is impossible.** The engine must be a frame loop that reveals a batch per frame.
-2. The **short** stories are where the writing feel actually lands: a 631-char remainder runs at ~96 chars/sec
-   (~1.5 chars/frame), which reads as brisk writing rather than a dump.
+1. **Per-character `setTimeout` is impossible.** The engine must be a frame loop that reveals a batch per frame — at
+   `dSteady ≈ 3.64ms` the longest story needs ~5 characters per frame, and `setTimeout` cannot go below ~4ms.
+2. **The writing feel is real on most of the set.** Two stories land under the ceiling and type at the full 12ms
+   cadence; five more run brisk at 6.4–9.1ms/char. Only the two Teknika stories are compressed hard enough to stream.
 
 ### What the ceiling means today
 
-With current content, every story hits the 6s ceiling:
+Computed against the **measured** 376-char teaser (an earlier draft used a wrong 200-char teaser, which made every
+story hit the ceiling and rendered the dynamic formula inert):
 
-| story | remainder | wants @12ms/char | actual | steady rate |
-|---|---|---|---|---|
-| 08-teknika-senior-engineer | 631 | 6.9s | 6.0s | ~96 chars/s — reads as writing |
-| 01-dubai-backend | 686 | 7.5s | 6.0s | ~114 chars/s |
-| 05-teknika-software-engineer | 897 | 9.9s | 6.0s | ~150 chars/s |
-| 02-assistt-full-stack | 1,019 | 11.2s | 6.0s | ~170 chars/s |
-| 09-solo-engineer | 1,153 | 12.7s | 6.0s | ~192 chars/s |
-| 10-amek-senior-engineer | 1,162 | 12.8s | 6.0s | ~194 chars/s |
-| 03-retavo-back-lead | 1,196 | 13.2s | 6.0s | ~199 chars/s |
-| 07-teknika-dev-manager | 1,854 | 20.4s | 6.0s | ~309 chars/s |
-| 06-teknika-backend-lead | 1,972 | 21.7s | 6.0s | ~329 chars/s — streams |
+| story | remainder | wants @12ms/char | actual | dSteady | feel |
+|---|---|---|---|---|---|
+| 08-teknika-senior-engineer | 455 | 5.0s | **5.0s** | 12.00ms | writing — under the ceiling |
+| 01-dubai-backend | 510 | 5.6s | **5.6s** | 12.00ms | writing — under the ceiling |
+| 05-teknika-software-engineer | 721 | 7.9s | 6.0s | 9.08ms | brisk |
+| 04-raineys-software-engineer | 839 | 9.2s | 6.0s | 7.80ms | brisk |
+| 02-assistt-full-stack | 843 | 9.3s | 6.0s | 7.76ms | brisk |
+| 09-solo-engineer | 977 | 10.7s | 6.0s | 6.70ms | brisk |
+| 10-amek-senior-engineer | 986 | 10.8s | 6.0s | 6.64ms | brisk |
+| 03-retavo-back-lead | 1,020 | 11.2s | 6.0s | 6.42ms | brisk |
+| 07-teknika-dev-manager | 1,678 | 18.5s | 6.0s | 3.90ms | streams |
+| 06-teknika-backend-lead | 1,796 | 19.8s | 6.0s | 3.64ms | streams |
 
-The dynamic formula is still correct to implement, and it is not dead code: a shorter role added later (say 300
-chars) resolves to ~3.3s at the true 12ms/char writing cadence instead of being padded out to 6s. It simply does not
-produce visible variation across *today's* ten stories, all of which are long enough to be compressed.
+**Two of ten run at the true 12ms writing cadence**, five are brisk (110–155 chars/s), and only the two long Teknika
+stories are compressed hard enough to read as streaming. The dynamic formula earns its place: it produces real
+variation across today's content, and a shorter role added later would type at the full writing cadence rather than
+being padded to 6s.
 
 ## Decisions
 
@@ -65,14 +69,32 @@ produce visible variation across *today's* ten stories, all of which are long en
 | Total duration | Dynamic, ceilinged at 6s. Aim for a 12ms/char steady writing rate; compress only when that would exceed 6s. The priority is the *feel of writing*, not finishing fast. |
 | Speed curve | Fast, then settle to a steady pace. The opening burst is 2× the steady rate — quicker, but not a blur. Decelerates to a constant rate, never to a crawl. |
 | Escape hatches | All three: click to finish instantly; `prefers-reduced-motion` skips entirely; auto-finish if scrolled out of view. |
-| Mobile truncation | Responsive: ~200 chars desktop, ~120 chars mobile. |
+| Teaser length | **Measured, not fixed.** Binary-search the character index where line 4 begins, then back off to a word boundary. Supersedes the "~200 desktop / ~120 mobile" budgets in an earlier draft — see below. |
 | Screen readers | Collapsed content leaves the accessibility tree. Disclosure pattern completed with `aria-controls`. |
 
-### Why responsive truncation
+### Why the teaser is measured, not a constant — corrected during plan review
 
-Today's `max-height: 77px` yields ~3 lines at *any* width. A fixed ~200 chars is ~3 lines on desktop but ~5–6 lines
-on mobile, which would visibly grow mobile cards. A responsive count preserves the existing ~3-line intent at both
-breakpoints.
+An earlier draft of this spec fixed the teaser at ~200 chars desktop / ~120 mobile, on the assumption that ~200 chars
+is about three lines. **Measurement in a real browser disproved both numbers**, and the correction matters:
+
+- At a 1440px viewport the `.story` box is **1118px** wide, and three lines hold **376 characters**. A 200-char teaser
+  would show ~1.4 lines — a visible regression against today's clamp. (`77px ÷ 25.575px line-height = 3.01`, so 77px
+  was indeed a 3-line design.)
+- At a 390px viewport the `.story` box is **still 874px** wide. The card never narrows. This is a **pre-existing
+  horizontal-overflow bug** on the site — the home page overflows too, and it is not caused by this work. So a
+  "mobile" budget is currently meaningless, and hardcoding one would bake in a number derived from a broken layout,
+  then silently regress the day the overflow is fixed.
+
+Measuring the real 3-line boundary is both more correct and simpler: it deletes the responsive branch entirely and
+reproduces today's collapsed height at any width, whatever the card is doing.
+
+This does **not** reopen the rejected "measure the visual clamp cut" option. That one was rejected because the boundary
+would be live and layout-dependent during typing. This measures **once**, at init, and still yields a fixed character
+index — the property that made truncation attractive. Typing from that index stays exact and trivial.
+
+The measurement is a binary search (~11 probes per story, since line tops increase monotonically down the flow), not a
+linear walk over ~2,000 characters. It re-runs on `document.fonts.ready`, because the pre-paint pass measures with
+fallback font metrics and would otherwise cut at the wrong place once the web font swaps in.
 
 ### Why the screen-reader change is acceptable
 
@@ -90,8 +112,12 @@ the order toggle in `about.astro`) and, for each collapsed story:
 
 1. Walks text nodes with a `TreeWalker`, building a flat character map `[{node, start, end, text}]`.
 2. Caches each node's full text.
-3. Truncates at the last word boundary at or before the budget (200 desktop / 120 mobile), appends `…`, and empties
-   the text nodes past the cut.
+3. Binary-searches the character index where line 4 begins, backs off to the last word boundary before it, appends
+   `…`, and empties the text nodes past the cut.
+
+**Emptied text nodes are not enough on their own.** An empty `<p>` still occupies a line and an empty `<li>` still
+paints its bullet via `li::before`, so any block whose text lies entirely past the cut must also be `display: none`.
+Without this, a collapsed card shows blank lines and stray bullets under its teaser.
 
 Running pre-paint avoids a flash of the full story. The `TreeWalker` approach preserves `<strong>` and `<ul>`/`<li>`
 markup — only `09-solo-engineer.md` has a list, but it must survive.
@@ -173,14 +199,14 @@ dFast   = dSteady / 2
 
 This is self-consistent: when a story lands under the ceiling, `dSteady` resolves to exactly `D_TARGET`.
 
-Worked examples:
+Worked examples, using the measured 376-char teaser:
 
-- **1,972-char remainder** — `T` clamps to 6000ms; `dSteady ≈ 3.32ms`, `dFast ≈ 1.66ms`. Both far below one frame,
-  which is exactly why the accumulator loop is required.
-- **631-char remainder** — `T` clamps to 6000ms; `dSteady ≈ 10.37ms`, `dFast ≈ 5.19ms`. Roughly one character every
-  frame or two: the writing feel.
-- **300-char remainder (hypothetical future entry)** — `T = 3300ms` (under the ceiling); `dSteady = 12ms` exactly,
-  `dFast = 6ms`.
+- **1,796-char remainder** (`06-teknika-backend-lead`) — wants 19.8s, so `T` clamps to 6000ms; `dSteady ≈ 3.64ms`,
+  `dFast ≈ 1.82ms`. Both far below one frame, which is exactly why the accumulator loop is required.
+- **986-char remainder** (`10-amek-senior-engineer`) — wants 10.8s, clamps to 6000ms; `dSteady ≈ 6.64ms`,
+  `dFast ≈ 3.32ms`. Brisk.
+- **455-char remainder** (`08-teknika-senior-engineer`) — wants 5.0s, **under the ceiling**, so `T = 5005ms` and
+  `dSteady = 12ms` exactly, `dFast = 6ms`. Roughly one character per frame: the writing feel, uncompressed.
 
 ### 5. Cursor
 
@@ -206,7 +232,8 @@ A single block `<span>` at the write head, moved to follow the current text node
 - **Streaming, not typing** on the long stories. See above. Inherent to the 6s ceiling; no parameter choice escapes it.
 - **Screen readers during the run.** Text is inserted progressively, so a screen reader that starts reading the
   instant the toggle is activated could encounter partial text. Bounded at 6s, and screen-reader reading is far slower
-  than even the slowest steady rate here (~96 chars/sec), so the text lands well before it is reached. Reduced-motion
+  than even the slowest steady rate here (~83 chars/sec at the uncompressed 12ms cadence), so the text lands well
+  before it is reached. Reduced-motion
   users skip the animation entirely.
 - **Find-in-page** will not match text that has not been typed yet, and will not match collapsed text at all
   (it is not in the DOM). Same as any disclosure widget.

--- a/docs/superpowers/specs/2026-07-17-story-typing-reveal-design.md
+++ b/docs/superpowers/specs/2026-07-17-story-typing-reveal-design.md
@@ -81,9 +81,25 @@ The existing `.story.collapsed { max-height: 77px }` rule is removed; truncation
 
 Order matters, and this is the part that most affects perceived quality:
 
-1. **Grow the box to full height first**, reusing the existing 320ms `max-height` transition. Full height is obtained
-   by measuring an offscreen clone carrying the full text.
+1. **Grow the box to full height first** (~320ms), then
 2. **Then** start typing into the settled box.
+
+**The height mechanism changes, and this is easy to get wrong.** Today `.story.collapsed { max-height: 77px }` does
+the clamping and `.story { transition: max-height 320ms }` animates it. Once truncation replaces the clamp, the
+collapsed box is simply the natural height of the teaser, and `max-height` no longer reserves anything — a `max-height`
+does not *force* a box to be tall, so the growth step would do nothing and the box would instead jump as text arrives.
+
+Reservation must therefore use `min-height`:
+
+1. Measure full height `H` from an offscreen clone carrying the full text.
+2. Set `min-height` to the box's *current* height, force a reflow, then set `min-height: H` so the transition has an
+   explicit start value (`auto` is not animatable). This mirrors the pattern the existing expand code already uses
+   with `scrollHeight`.
+3. Transition `min-height` over 320ms with `--ease-standard`. The box grows, empty below the teaser.
+4. Type. Text fills the reserved space.
+5. On completion, clear the inline `min-height` — natural height now equals `H`.
+
+The `.story` transition property changes from `max-height` to `min-height` accordingly.
 
 Text fills a pre-sized area instead of pushing the page down for three seconds. Two consequences: no continuous layout
 shift while the reader is reading, and the timeline rail re-syncs **once** after expansion rather than every frame for

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "joe-inz-personal-website",
   "type": "module",
-  "version": "1.1.1",
+  "version": "1.2.0",
   "description": "A personal website built with Astro and Tailwind CSS.",
   "scripts": {
     "dev": "astro dev",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "joe-inz-personal-website",
   "type": "module",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "description": "A personal website built with Astro and Tailwind CSS.",
   "scripts": {
     "dev": "astro dev",

--- a/src/components/ExperienceCard.astro
+++ b/src/components/ExperienceCard.astro
@@ -6,9 +6,10 @@ import {formatExperienceDate, isCurrentRole} from '../utils/experiences';
 
 export interface Props {
     experience: CollectionEntry<'experiences'>;
+    index: number;
 }
 
-const {experience} = Astro.props;
+const {experience, index} = Astro.props;
 const {Content} = await render(experience);
 const current = isCurrentRole(experience);
 const {roleName, companyName, companyUrl, startDate, endDate, location, workType, tags} = experience.data;
@@ -16,7 +17,7 @@ const workTypeLabel = workType.charAt(0).toUpperCase() + workType.slice(1);
 const startYear = startDate.slice(0, 4);
 ---
 
-<div class='timeline-entry grid grid-cols-[28px_1fr] md:grid-cols-[48px_1fr] reveal'>
+<div class='timeline-entry grid grid-cols-[28px_1fr] md:grid-cols-[48px_1fr] reveal' data-index={index}>
     <div class='flex flex-col items-center pt-12 md:pt-6'>
         <span class='hidden md:block text-[11px] font-semibold text-muted tabular-nums leading-[14px] mb-[10px]'>{startYear}</span>
         <span class='w-3.5 h-3.5 rounded-full border-2 border-accent bg-surface relative z-[1] shrink-0'></span>

--- a/src/components/ExperienceCard.astro
+++ b/src/components/ExperienceCard.astro
@@ -13,10 +13,12 @@ const {Content} = await render(experience);
 const current = isCurrentRole(experience);
 const {roleName, companyName, companyUrl, startDate, endDate, location, workType, tags} = experience.data;
 const workTypeLabel = workType.charAt(0).toUpperCase() + workType.slice(1);
+const startYear = startDate.slice(0, 4);
 ---
 
 <div class='timeline-entry grid grid-cols-[28px_1fr] md:grid-cols-[48px_1fr] reveal'>
-    <div class='flex flex-col items-center pt-12'>
+    <div class='flex flex-col items-center pt-12 md:pt-6'>
+        <span class='hidden md:block text-[11px] font-semibold text-muted tabular-nums leading-[14px] mb-[10px]'>{startYear}</span>
         <span class='w-3.5 h-3.5 rounded-full border-2 border-accent bg-surface relative z-[1] shrink-0'></span>
     </div>
 

--- a/src/components/ExperienceCard.astro
+++ b/src/components/ExperienceCard.astro
@@ -17,7 +17,7 @@ const workTypeLabel = workType.charAt(0).toUpperCase() + workType.slice(1);
 const startYear = startDate.slice(0, 4);
 ---
 
-<div class='timeline-entry grid grid-cols-[28px_1fr] md:grid-cols-[48px_1fr] reveal' data-index={index}>
+<div class='timeline-entry grid grid-cols-[28px_minmax(0,1fr)] md:grid-cols-[48px_minmax(0,1fr)] reveal' data-index={index}>
     <div class='flex flex-col items-center pt-12 md:pt-6'>
         <span class='hidden md:block text-[11px] font-semibold text-muted tabular-nums leading-[14px] mb-[10px]'>{startYear}</span>
         <span class='w-3.5 h-3.5 rounded-full border-2 border-accent bg-surface relative z-[1] shrink-0'></span>

--- a/src/components/ExperienceCard.astro
+++ b/src/components/ExperienceCard.astro
@@ -40,11 +40,13 @@ const startYear = startDate.slice(0, 4);
             <span>{companyName && ' · '}{formatExperienceDate(startDate)} → {formatExperienceDate(endDate)} · {location}</span>
         </p>
 
-        <div class:list={['story text-[15.5px] leading-[1.65] text-body', !current && 'collapsed']}>
+        <div id={`story-${experience.id}`}
+             class:list={['story text-[15.5px] leading-[1.65] text-body', !current && 'collapsed']}>
             <Content/>
         </div>
         <button class='story-toggle text-sm font-semibold text-info mt-4'
-                aria-expanded={current ? 'true' : 'false'}>
+                aria-expanded={current ? 'true' : 'false'}
+                aria-controls={`story-${experience.id}`}>
             {current ? 'Show less ↑' : 'Read the story ↓'}
         </button>
 
@@ -57,12 +59,11 @@ const startYear = startDate.slice(0, 4);
 <style>
     .story {
         overflow: hidden;
-        transition: max-height 320ms var(--ease-standard);
-    }
-
-    /* ~3 lines at 15.5px / 1.65 */
-    .story.collapsed {
-        max-height: 77px;
+        /* min-height, not max-height: once truncation replaces the clamp there is no
+           overflow to cap, and a max-height cannot RESERVE space. Task 2 grows this to
+           the story's full height before typing so the page does not shift while the
+           reader reads. */
+        transition: min-height 320ms var(--ease-standard);
     }
 
     .story :global(p + p) {
@@ -95,34 +96,3 @@ const startYear = startDate.slice(0, 4);
         color: var(--text-strong);
     }
 </style>
-
-<script>
-    // One delegated handler animates every story's expand/collapse via max-height.
-    if (!(window as any).__storyToggleBound) {
-        (window as any).__storyToggleBound = true;
-        document.addEventListener('click', (event) => {
-            const button = (event.target as Element | null)?.closest('.story-toggle');
-            if (!button) return;
-            const story = button.closest('.story-card')?.querySelector('.story') as HTMLElement | null;
-            if (!story) return;
-
-            const collapsed = story.classList.contains('collapsed');
-            if (collapsed) {
-                story.classList.remove('collapsed');
-                story.style.maxHeight = `${story.scrollHeight}px`;
-                story.addEventListener('transitionend', () => {
-                    story.style.maxHeight = '';
-                }, {once: true});
-                button.textContent = 'Show less ↑';
-                button.setAttribute('aria-expanded', 'true');
-            } else {
-                story.style.maxHeight = `${story.scrollHeight}px`;
-                void story.offsetHeight;
-                story.style.maxHeight = '';
-                story.classList.add('collapsed');
-                button.textContent = 'Read the story ↓';
-                button.setAttribute('aria-expanded', 'false');
-            }
-        });
-    }
-</script>

--- a/src/components/ExperienceCard.astro
+++ b/src/components/ExperienceCard.astro
@@ -23,6 +23,9 @@ const startYear = startDate.slice(0, 4);
     </div>
 
     <div class='cardx p-6 md:p-10 mb-7 story-card'>
+        <p class='direction-cue kicker mb-2'>
+            <span class='cue-back'>Before that</span><span class='cue-forward'>Then</span>
+        </p>
         <div class='flex items-center gap-3 flex-wrap mb-3'>
             <h3 class='font-display text-[27px] font-semibold text-strong leading-tight'>{roleName}</h3>
             {current && <span class='badge-accent'>Current</span>}

--- a/src/components/PostsByYear.astro
+++ b/src/components/PostsByYear.astro
@@ -32,7 +32,7 @@ const shortDate = (date: Date) =>
 ---
 
 {groupedPosts.map(({year, posts}) => (
-        <div class='grid md:grid-cols-[200px_1fr] gap-4 md:gap-12 border-t border-hairline first:border-t-0 py-10 reveal'>
+        <div class='grid md:grid-cols-[200px_minmax(0,1fr)] gap-4 md:gap-12 border-t border-hairline first:border-t-0 py-10 reveal'>
             <div class='font-display text-[56px] md:text-[72px] font-semibold text-accent leading-none'>{year}</div>
             <div>
                 {posts.map((post) => (

--- a/src/components/SocialLinks.astro
+++ b/src/components/SocialLinks.astro
@@ -1,0 +1,26 @@
+---
+import {Image} from 'astro:assets';
+import GithubInk from '@src/assets/img/github-ink.svg';
+import GithubCream from '@src/assets/img/github-cream.svg';
+import LinkedinInk from '@src/assets/img/linkedin-ink.svg';
+import LinkedinCream from '@src/assets/img/linkedin-cream.svg';
+import {GITHUB_ACCOUNT, LINKEDIN_ACCOUNT} from '../consts';
+
+interface Props {
+    class?: string;
+    size?: number;
+}
+
+const {class: className, size = 20} = Astro.props;
+---
+
+<div class:list={['flex items-center gap-4', className]}>
+    <a href={GITHUB_ACCOUNT} target='_blank' rel='noopener' class='p-1' aria-label='GitHub'>
+        <Image src={GithubInk} width={size} height={size} alt='' class='dark:hidden'/>
+        <Image src={GithubCream} width={size} height={size} alt='' class='hidden dark:block'/>
+    </a>
+    <a href={LINKEDIN_ACCOUNT} target='_blank' rel='noopener' class='p-1' aria-label='LinkedIn'>
+        <Image src={LinkedinInk} width={size} height={size} alt='' class='dark:hidden'/>
+        <Image src={LinkedinCream} width={size} height={size} alt='' class='hidden dark:block'/>
+    </a>
+</div>

--- a/src/components/StackLine.astro
+++ b/src/components/StackLine.astro
@@ -8,9 +8,6 @@ const {tags, label} = Astro.props;
 ---
 
 <p class='stack-line'>
-    {label && <span class='stack-label'>{label}</span>}{
-        tags.map((tag, i) => (
-            <Fragment>{i > 0 && <span class='stack-dot'>·</span>}<span>{tag}</span></Fragment>
-        ))
-    }
+    {label && <span class='stack-label'>{label}</span>}
+    {tags.map((tag) => <span class='stack-tag'>{tag}</span>)}
 </p>

--- a/src/layouts/components/Footer.astro
+++ b/src/layouts/components/Footer.astro
@@ -1,12 +1,14 @@
 ---
 import Byline from '@src/components/Byline.astro';
+import SocialLinks from '@src/components/SocialLinks.astro';
 import {FULL_NAME, NICKNAME} from '../../consts';
 const year = new Date().getFullYear();
 ---
 
 <footer class='border-t border-hairline'>
-    <div class='shell flex flex-col sm:flex-row items-center justify-between gap-4 py-8'>
+    <div class='shell flex flex-col sm:flex-row items-center justify-between gap-5 py-8'>
         <Byline/>
+        <SocialLinks size={22}/>
         <p class='text-[13px] text-muted'>© {year} {FULL_NAME} · {NICKNAME}</p>
     </div>
 </footer>

--- a/src/layouts/components/Header.astro
+++ b/src/layouts/components/Header.astro
@@ -242,8 +242,20 @@ const isActive = (link: string) =>
                 if (!btn || !menu || menu.hidden) return;
                 btn.setAttribute('aria-expanded', 'false');
                 menu.classList.remove('open');
-                if (reduce()) menu.hidden = true;
-                else menu.addEventListener('transitionend', () => {menu.hidden = true;}, {once: true});
+                if (reduce()) {
+                    menu.hidden = true;
+                } else {
+                    /* Guard on target: the panel transitions two properties, and
+                       transitionend bubbles — react only to the panel's own transition,
+                       and drop the listener manually (not `once`, which would fire on the
+                       first bubbled child event and never hide). */
+                    const onEnd = (event) => {
+                        if (event.target !== menu) return;
+                        menu.hidden = true;
+                        menu.removeEventListener('transitionend', onEnd);
+                    };
+                    menu.addEventListener('transitionend', onEnd);
+                }
                 if (returnFocus) btn.focus();
             };
 

--- a/src/layouts/components/Header.astro
+++ b/src/layouts/components/Header.astro
@@ -47,27 +47,62 @@ const isActive = (link: string) =>
         <div class='flex items-center gap-4'>
             <SocialLinks/>
 
-            <button id='themeToggle'
-                    class='flex items-center rounded-full border border-hairline p-[3px]'
+            <button class='theme-toggle flex items-center rounded-full border border-hairline p-[3px]'
                     aria-pressed='false'
                     aria-label='Switch between light and dark mode'>
-                <span class='toggle-seg toggle-seg-light'>Light</span>
-                <span class='toggle-seg toggle-seg-dark'>Dark</span>
+                <span class='toggle-seg toggle-seg-light'>
+                    <svg class='toggle-ic' viewBox='0 0 24 24' fill='none' stroke='currentColor'
+                         stroke-width='2' stroke-linecap='round' aria-hidden='true'>
+                        <circle cx='12' cy='12' r='4.2'/>
+                        <line x1='12' y1='1.5' x2='12' y2='4'/><line x1='12' y1='20' x2='12' y2='22.5'/>
+                        <line x1='1.5' y1='12' x2='4' y2='12'/><line x1='20' y1='12' x2='22.5' y2='12'/>
+                        <line x1='4.3' y1='4.3' x2='6' y2='6'/><line x1='18' y1='18' x2='19.7' y2='19.7'/>
+                        <line x1='19.7' y1='4.3' x2='18' y2='6'/><line x1='6' y1='18' x2='4.3' y2='19.7'/>
+                    </svg>
+                    <span class='hidden md:inline'>Light</span>
+                </span>
+                <span class='toggle-seg toggle-seg-dark'>
+                    <svg class='toggle-ic' viewBox='0 0 24 24' aria-hidden='true'>
+                        <circle cx='12' cy='12' r='9' fill='currentColor'/>
+                        <circle cx='8.6' cy='8.8' r='1.9' fill='#000' fill-opacity='.17'/>
+                        <circle cx='15.2' cy='13.4' r='2.5' fill='#000' fill-opacity='.14'/>
+                        <circle cx='9.8' cy='15.6' r='1.3' fill='#000' fill-opacity='.15'/>
+                    </svg>
+                    <span class='hidden md:inline'>Dark</span>
+                </span>
             </button>
         </div>
     </nav>
 
     <style>
         .toggle-seg {
+            display: inline-flex;
+            align-items: center;
+            gap: 6px;
             font-size: 10px;
             font-weight: 600;
             text-transform: uppercase;
             letter-spacing: .08em;
-            padding: 5px 12px;
+            padding: 5px;
             border-radius: 999px;
             color: var(--text-muted);
             transition: background-color var(--dur-base) var(--ease-standard),
                 color var(--dur-base) var(--ease-standard);
+        }
+
+        /* Icon-only on mobile; the label span is hidden below md, so square padding
+           keeps the segment circular. Room for the label appears at md. */
+        @media (min-width: 768px) {
+            .toggle-seg {
+                padding: 5px 12px;
+            }
+        }
+
+        .toggle-ic {
+            width: 15px;
+            height: 15px;
+            display: block;
+            flex: 0 0 auto;
         }
 
         :global(html:not(.theme-dark)) .toggle-seg-light,
@@ -83,7 +118,7 @@ const isActive = (link: string) =>
 
             const syncPressed = () => {
                 const dark = document.documentElement.classList.contains('theme-dark');
-                document.querySelectorAll('#themeToggle').forEach((btn) =>
+                document.querySelectorAll('.theme-toggle').forEach((btn) =>
                     btn.setAttribute('aria-pressed', String(dark)));
                 return dark;
             };
@@ -98,7 +133,7 @@ const isActive = (link: string) =>
             };
 
             document.addEventListener('click', (event) => {
-                if (!event.target.closest('#themeToggle')) return;
+                if (!event.target.closest('.theme-toggle')) return;
                 document.documentElement.classList.toggle('theme-dark');
                 const dark = syncPressed();
                 localStorage.setItem('theme', dark ? 'dark' : 'light');

--- a/src/layouts/components/Header.astro
+++ b/src/layouts/components/Header.astro
@@ -2,11 +2,8 @@
 import {Image} from 'astro:assets';
 import LogoLight from '@src/assets/img/logo.png';
 import LogoDark from '@src/assets/img/logo-transparent.png';
-import GithubInk from '@src/assets/img/github-ink.svg';
-import GithubCream from '@src/assets/img/github-cream.svg';
-import LinkedinInk from '@src/assets/img/linkedin-ink.svg';
-import LinkedinCream from '@src/assets/img/linkedin-cream.svg';
-import {GITHUB_ACCOUNT, LINKEDIN_ACCOUNT, NICKNAME} from '../../consts';
+import SocialLinks from '@src/components/SocialLinks.astro';
+import {NICKNAME} from '../../consts';
 
 const menu = [
     {link: '/', label: 'Home'},
@@ -48,14 +45,7 @@ const isActive = (link: string) =>
         </div>
 
         <div class='flex items-center gap-4'>
-            <a href={GITHUB_ACCOUNT} target='_blank' class='p-1' aria-label='GitHub'>
-                <Image src={GithubInk} width={20} height={20} alt='' class='dark:hidden'/>
-                <Image src={GithubCream} width={20} height={20} alt='' class='hidden dark:block'/>
-            </a>
-            <a href={LINKEDIN_ACCOUNT} target='_blank' class='p-1' aria-label='LinkedIn'>
-                <Image src={LinkedinInk} width={20} height={20} alt='' class='dark:hidden'/>
-                <Image src={LinkedinCream} width={20} height={20} alt='' class='hidden dark:block'/>
-            </a>
+            <SocialLinks/>
 
             <button id='themeToggle'
                     class='flex items-center rounded-full border border-hairline p-[3px]'

--- a/src/layouts/components/Header.astro
+++ b/src/layouts/components/Header.astro
@@ -29,7 +29,7 @@ const isActive = (link: string) =>
                    class='h-12 w-12 hidden dark:block'/>
         </a>
 
-        <div class='flex items-center gap-6 md:gap-9'>
+        <div class='hidden md:flex items-center gap-6 md:gap-9'>
             {menu.map((item) => (
                     <a href={item.link}
                        class:list={[
@@ -72,7 +72,32 @@ const isActive = (link: string) =>
                 </span>
             </button>
         </div>
+
+        <button type='button'
+                class='menu-toggle md:hidden flex flex-col justify-center gap-[5px] shrink-0 p-2 -mr-2'
+                aria-label='Menu' aria-expanded='false' aria-controls='mobileMenu'>
+            <span class='menu-bar'></span>
+            <span class='menu-bar'></span>
+            <span class='menu-bar'></span>
+        </button>
     </nav>
+
+    <div id='mobileMenu' class='mobile-menu md:hidden' hidden>
+        <nav class='shell flex flex-col py-2' aria-label='Mobile'>
+            {menu.map((item) => (
+                    <a href={item.link}
+                       class:list={[
+                           'py-3 text-[17px] border-b border-hairline last:border-b-0',
+                           isActive(item.link)
+                               ? 'text-accent font-semibold'
+                               : 'text-body font-medium'
+                       ]}
+                       aria-current={isActive(item.link) ? 'page' : undefined}>
+                        {item.label}
+                    </a>
+            ))}
+        </nav>
+    </div>
 
     <style>
         .toggle-seg {
@@ -110,6 +135,50 @@ const isActive = (link: string) =>
             background: var(--accent);
             color: var(--on-accent);
         }
+
+        .menu-bar {
+            width: 22px;
+            height: 2px;
+            border-radius: 2px;
+            background: var(--text-strong);
+            transition: transform var(--dur-base) var(--ease-standard),
+                opacity var(--dur-base) var(--ease-standard);
+        }
+
+        /* Hamburger morphs to an X while the menu is open. */
+        .menu-toggle[aria-expanded='true'] .menu-bar:nth-child(1) {
+            transform: translateY(7px) rotate(45deg);
+        }
+        .menu-toggle[aria-expanded='true'] .menu-bar:nth-child(2) {
+            opacity: 0;
+        }
+        .menu-toggle[aria-expanded='true'] .menu-bar:nth-child(3) {
+            transform: translateY(-7px) rotate(-45deg);
+        }
+
+        .mobile-menu {
+            overflow: hidden;
+            border-top: 1px solid var(--hairline);
+            transform: translateY(-8px);
+            opacity: 0;
+            transition: transform var(--dur-base) var(--ease-standard),
+                opacity var(--dur-base) var(--ease-standard);
+        }
+        .mobile-menu.open {
+            transform: none;
+            opacity: 1;
+        }
+
+        @media (prefers-reduced-motion: reduce) {
+            .menu-bar,
+            .mobile-menu {
+                transition: none;
+            }
+            .mobile-menu {
+                transform: none;
+                opacity: 1;
+            }
+        }
     </style>
 
     <script is:inline>
@@ -141,6 +210,69 @@ const isActive = (link: string) =>
             });
 
             document.addEventListener('astro:page-load', syncPressed);
+        }
+    </script>
+
+    <script is:inline>
+        if (!window.__mobileMenuBound) {
+            window.__mobileMenuBound = true;
+
+            const reduce = () => window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+            const els = () => ({
+                btn: document.querySelector('.menu-toggle'),
+                menu: document.getElementById('mobileMenu')
+            });
+
+            const openMenu = () => {
+                const {btn, menu} = els();
+                if (!btn || !menu) return;
+                menu.hidden = false;
+                btn.setAttribute('aria-expanded', 'true');
+                /* Slide in on the frame after unhiding so the transition has a start state.
+                   `hidden` (display:none) means the closed menu is out of the a11y tree and
+                   not focusable — no focus trap needed for a non-modal disclosure. */
+                if (reduce()) menu.classList.add('open');
+                else requestAnimationFrame(() => requestAnimationFrame(() => menu.classList.add('open')));
+                const first = menu.querySelector('a');
+                if (first) first.focus();
+            };
+
+            const closeMenu = (returnFocus) => {
+                const {btn, menu} = els();
+                if (!btn || !menu || menu.hidden) return;
+                btn.setAttribute('aria-expanded', 'false');
+                menu.classList.remove('open');
+                if (reduce()) menu.hidden = true;
+                else menu.addEventListener('transitionend', () => {menu.hidden = true;}, {once: true});
+                if (returnFocus) btn.focus();
+            };
+
+            document.addEventListener('click', (event) => {
+                if (event.target.closest('.menu-toggle')) {
+                    const {menu} = els();
+                    if (menu && menu.hidden) openMenu();
+                    else closeMenu(true);
+                    return;
+                }
+                /* A click anywhere outside the header closes an open menu. Clicks on a menu
+                   link fall through to navigation, which closes it via astro:page-load. */
+                const {menu} = els();
+                if (menu && !menu.hidden && !event.target.closest('header')) closeMenu(false);
+            });
+
+            document.addEventListener('keydown', (event) => {
+                if (event.key === 'Escape') closeMenu(true);
+            });
+
+            /* Never leave the menu open across a View-Transitions navigation. */
+            document.addEventListener('astro:page-load', () => {
+                const {btn, menu} = els();
+                if (menu) {
+                    menu.hidden = true;
+                    menu.classList.remove('open');
+                }
+                if (btn) btn.setAttribute('aria-expanded', 'false');
+            });
         }
     </script>
 </header>

--- a/src/pages/about.astro
+++ b/src/pages/about.astro
@@ -89,6 +89,12 @@ const education = (await getCollection('education')).sort(
         display: inline;
     }
 
+    /* The leading card has nothing before it — true in either order, so :first-child
+       handles both without position logic. */
+    .timeline-entry:first-child .direction-cue {
+        display: none;
+    }
+
     .timeline-entry .story-card {
         /* Anchor the left edge so the gap to the timeline rail never changes */
         transform-origin: left center;

--- a/src/pages/about.astro
+++ b/src/pages/about.astro
@@ -50,7 +50,17 @@ const education = (await getCollection('education')).sort(
                 <div id='timelineMarker'
                      class='absolute left-[7px] md:left-[17px] top-0 w-3.5 h-3.5 rounded-full bg-accent shadow-[0_0_0_5px_var(--accent-wash)] transition-transform duration-200 ease-out z-[2]'
                      aria-hidden='true'></div>
-                {experiences.map((exp) => <ExperienceCard experience={exp}/>)}
+                {experiences.map((exp, index) => (
+                    <Fragment>
+                        <ExperienceCard experience={exp}/>
+                        {index === 0 && (
+                            <div id='timelineFlashback' class='grid grid-cols-[28px_1fr] md:grid-cols-[48px_1fr]'>
+                                <div></div>
+                                <p class='kicker mb-7'>How I got here</p>
+                            </div>
+                        )}
+                    </Fragment>
+                ))}
             </div>
         </div>
     </section>

--- a/src/pages/about.astro
+++ b/src/pages/about.astro
@@ -172,13 +172,22 @@ const education = (await getCollection('education')).sort(
        `linear`, deliberately, NOT --ease-standard. That token is an ease-out, and easing the
        whole animation front-loads the travel: measured, it covered most of its distance in
        the first 500ms and then crawled — a blink, then nothing. A traveling band has to move
-       at constant speed to read as a sweep. Easing is for transitions, not for this. */
+       at constant speed to read as a sweep. Easing is for transitions, not for this.
+
+       The 100% -> 0% range is a hard constraint, NOT a stylistic choice. With
+       background-size:250% the offset is (container - image) * P/100, so the image only
+       covers the label while P stays within 0-100%. Outside that range the uncovered text
+       has no background at all, and because background-clip:text pairs with
+       color:transparent, THE LABEL VANISHES. An earlier version swept 150% -> -150% and the
+       text was wiped out for the whole 2.75s rest. Within 0-100% the band still travels the
+       full width of the label — at P=100 it sits just left of it, at P=0 just right — so
+       nothing is lost by staying in range. */
     @keyframes toggle-glint {
         0% {
-            background-position: 150% 0;
+            background-position: 100% 0;
         }
         45%, 100% {
-            background-position: -150% 0;
+            background-position: 0% 0;
         }
     }
 

--- a/src/pages/about.astro
+++ b/src/pages/about.astro
@@ -57,7 +57,7 @@ const education = (await getCollection('education')).sort(
                      aria-hidden='true'></div>
                 {experiences.map((exp, index) => (
                     <Fragment>
-                        <ExperienceCard experience={exp}/>
+                        <ExperienceCard experience={exp} index={index}/>
                         {index === 0 && (
                             <div id='timelineFlashback' class='grid grid-cols-[28px_1fr] md:grid-cols-[48px_1fr]'>
                                 <div aria-hidden='true'></div>
@@ -118,6 +118,10 @@ const education = (await getCollection('education')).sort(
         background: var(--accent-wash);
         color: var(--text-strong);
         font-weight: 600;
+    }
+
+    .order-story #timelineFlashback {
+        display: none;
     }
 
     .timeline-entry .story-card {
@@ -205,5 +209,65 @@ const education = (await getCollection('education')).sort(
         if ('ResizeObserver' in window) {
             new ResizeObserver(request).observe(document.documentElement);
         }
+    }
+</script>
+
+<script is:inline>
+    if (!window.__orderToggleBound) {
+        window.__orderToggleBound = true;
+
+        const STORAGE_KEY = 'experienceOrder';
+
+        const applyOrder = (order) => {
+            const section = document.getElementById('experienceSection');
+            const timeline = document.getElementById('experienceTimeline');
+            const flashback = document.getElementById('timelineFlashback');
+            if (!section || !timeline) return;
+
+            // Sort back to render order first; after a reversal the DOM is no longer authoritative.
+            const entries = Array.from(timeline.querySelectorAll('.timeline-entry'))
+                .sort((a, b) => Number(a.dataset.index) - Number(b.dataset.index));
+            const ordered = order === 'story' ? entries.slice().reverse() : entries;
+
+            // Moving real nodes, not CSS column-reverse: the rail script pairs
+            // querySelectorAll order with offsetTop and would desync otherwise.
+            ordered.forEach((entry) => timeline.appendChild(entry));
+
+            // The flashback frame only makes sense walking backwards; in story order
+            // the current role is last, so it is hidden by CSS and its position is moot.
+            if (flashback) timeline.insertBefore(flashback, ordered[1] ?? null);
+
+            section.classList.toggle('order-story', order === 'story');
+
+            document.querySelectorAll('.order-btn').forEach((button) => {
+                button.setAttribute('aria-pressed', String(button.dataset.order === order));
+            });
+
+            // The rail's update() is closed over; it already listens for resize.
+            window.dispatchEvent(new Event('resize'));
+        };
+
+        const readStoredOrder = () => {
+            try {
+                return localStorage.getItem(STORAGE_KEY) === 'story' ? 'story' : 'latest';
+            } catch {
+                return 'latest';
+            }
+        };
+
+        document.addEventListener('click', (event) => {
+            const button = event.target?.closest?.('.order-btn');
+            if (!button) return;
+            const order = button.dataset.order;
+            try {
+                localStorage.setItem(STORAGE_KEY, order);
+            } catch {
+                /* private mode — the toggle still works for this page view */
+            }
+            applyOrder(order);
+        });
+
+        // Re-apply on first load and after each View Transitions navigation.
+        document.addEventListener('astro:page-load', () => applyOrder(readStoredOrder()));
     }
 </script>

--- a/src/pages/about.astro
+++ b/src/pages/about.astro
@@ -547,12 +547,26 @@ const education = (await getCollection('education')).sort(
             const fullHeight = story.scrollHeight;
             reveal(story, s.cut, true);
 
-            /* Reserve the space before typing so nothing below the card shifts while the
-               reader reads. min-height needs an explicit start value — auto will not
-               transition. */
+            /* Reserve ONE LINE MORE than the finished text needs.
+
+               `p { text-wrap: pretty }` (global.css) rebalances a paragraph to avoid
+               orphans. A half-typed paragraph is a complete paragraph as far as CSS is
+               concerned, so mid-run it can push its last word onto an extra line and render
+               TALLER than the same paragraph will once fully revealed. Reserving only
+               fullHeight therefore leaves the box overflowing by one line for part of the
+               run, jittering everything below it — measured at exactly +25px on
+               06-teknika-backend-lead, and 0.98-1.02 line-heights across all eight stories,
+               which is what makes one line a safe bound.
+
+               The cursor is NOT the cause here: it is width:0 with an absolutely-positioned
+               ::after and measures 0x0, verified layout-neutral. Do not "fix" this by
+               padding for the cursor.
+
+               min-height needs an explicit start value — auto will not transition. */
+            const lineHeight = parseFloat(getComputedStyle(story).lineHeight) || 0;
             story.style.minHeight = story.offsetHeight + 'px';
             void story.offsetHeight;
-            story.style.minHeight = fullHeight + 'px';
+            story.style.minHeight = fullHeight + lineHeight + 'px';
 
             /* Cancel any grow timer still pending from a previous expand. Without this, a
                fast expand -> collapse -> expand inside the 340ms grow window leaves a stale

--- a/src/pages/about.astro
+++ b/src/pages/about.astro
@@ -518,6 +518,12 @@ const education = (await getCollection('education')).sort(
             button.textContent = 'Show less ↑';
             button.setAttribute('aria-expanded', 'true');
 
+            if (window.matchMedia('(prefers-reduced-motion: reduce)').matches) {
+                reveal(story, s.total);
+                story.style.minHeight = '';
+                return;
+            }
+
             /* Measure the full height by briefly revealing everything. This is synchronous
                and forces one reflow, so the browser never paints the revealed state. */
             reveal(story, s.total);
@@ -551,21 +557,40 @@ const education = (await getCollection('education')).sort(
         };
 
         document.addEventListener('click', (event) => {
+            const card = event.target?.closest('.story-card');
+            if (!card) return;
+            const story = card.querySelector('.story');
+            if (!story || !state.has(story)) return;
+
+            /* Mid-run, ANY click on the card finishes immediately — including one on the
+               toggle, which must not collapse a card the reader is waiting to read. */
+            if (state.get(story).typing) {
+                finish(story);
+                return;
+            }
+
             const button = event.target?.closest('.story-toggle');
             if (!button) return;
-            const story = button.closest('.story-card')?.querySelector('.story');
-            if (!story || !state.has(story)) return;
             if (story.classList.contains('collapsed')) expand(story, button);
             else collapse(story, button);
         });
 
-        /* Runs before paint so the full story never flashes; astro:after-swap covers
-           View Transitions navigations, matching the other scripts on this page. */
+        /* A card typing off-screen wastes frames and strands the reader with a
+           half-written story when they scroll back. */
+        const offscreenObserver = new IntersectionObserver((entries) => {
+            entries.forEach((entry) => {
+                if (entry.isIntersecting) return;
+                const story = entry.target.querySelector('.story');
+                if (story && state.has(story) && state.get(story).typing) finish(story);
+            });
+        }, {threshold: 0});
+
         const initStories = () => {
             document.querySelectorAll('.story').forEach((story) => {
                 if (!state.has(story)) state.set(story, buildState(story));
                 if (story.classList.contains('collapsed')) truncate(story);
             });
+            document.querySelectorAll('.story-card').forEach((card) => offscreenObserver.observe(card));
         };
         initStories();
         document.addEventListener('astro:after-swap', initStories);

--- a/src/pages/about.astro
+++ b/src/pages/about.astro
@@ -55,17 +55,7 @@ const education = (await getCollection('education')).sort(
                 <div id='timelineMarker'
                      class='absolute left-[7px] md:left-[17px] top-0 w-3.5 h-3.5 rounded-full bg-accent shadow-[0_0_0_5px_var(--accent-wash)] transition-transform duration-200 ease-out z-[2]'
                      aria-hidden='true'></div>
-                {experiences.map((exp, index) => (
-                    <Fragment>
-                        <ExperienceCard experience={exp} index={index}/>
-                        {index === 0 && (
-                            <div id='timelineFlashback' class='grid grid-cols-[28px_1fr] md:grid-cols-[48px_1fr]'>
-                                <div aria-hidden='true'></div>
-                                <h3 class='kicker mb-7'>How I got here</h3>
-                            </div>
-                        )}
-                    </Fragment>
-                ))}
+                {experiences.map((exp, index) => <ExperienceCard experience={exp} index={index}/>)}
             </div>
         </div>
     </section>
@@ -104,15 +94,11 @@ const education = (await getCollection('education')).sort(
         display: inline;
     }
 
-    .order-story #timelineFlashback {
-        display: none;
-    }
-
     /* The leading card has nothing before it. "Not preceded by another entry"
        is true of whichever card leads, in either order, and is immune to the
-       rail divs, the flashback, and the script Vite injects between them in dev.
-       Do not narrow this to :first-child or an adjacent-sibling form — both
-       assume a fixed node layout and silently match nothing. */
+       rail divs and the script Vite injects between them in dev. Do not narrow
+       this to :first-child or an adjacent-sibling form — both assume a fixed
+       node layout and silently match nothing. */
     .timeline-entry:not(.timeline-entry ~ .timeline-entry) .direction-cue {
         display: none;
     }
@@ -333,7 +319,6 @@ const education = (await getCollection('education')).sort(
         const applyOrder = (order) => {
             const section = document.getElementById('experienceSection');
             const timeline = document.getElementById('experienceTimeline');
-            const flashback = document.getElementById('timelineFlashback');
             if (!section || !timeline) return;
 
             // Sort back to render order first; after a reversal the DOM is no longer authoritative.
@@ -344,11 +329,6 @@ const education = (await getCollection('education')).sort(
             // Moving real nodes, not CSS column-reverse: the rail script pairs
             // querySelectorAll order with offsetTop and would desync otherwise.
             ordered.forEach((entry) => timeline.appendChild(entry));
-
-            // The re-append strands the flashback at the front, so re-seat it after
-            // the leading entry. In story order that lands it mid-list, which is moot —
-            // CSS hides it there.
-            if (flashback) timeline.insertBefore(flashback, ordered[1] ?? null);
 
             section.classList.toggle('order-story', order === 'story');
 

--- a/src/pages/about.astro
+++ b/src/pages/about.astro
@@ -127,18 +127,32 @@ const education = (await getCollection('education')).sort(
         font-weight: 600;
     }
 
-    /* The cursor is created by script, so it cannot live in ExperienceCard's scoped styles. */
+    /* The cursor is created by script, so it cannot live in ExperienceCard's scoped styles.
+
+       It MUST occupy zero width in the flow. It is inserted at the write head on every
+       frame, so if it took real inline width it would wrap onto a new line whenever the
+       write head neared the end of a full line — pushing the box past the min-height
+       reserved before it existed, which is the exact layout shift the grow-then-type
+       sequence exists to prevent. Measured: reserved 497px vs 522px actual. The block is
+       therefore painted by an absolutely-positioned ::after, which is outside the flow. */
     .type-cursor {
+        position: relative;
         display: inline-block;
+        width: 0;
+    }
+
+    .type-cursor::after {
+        content: '';
+        position: absolute;
+        left: 1px;
+        bottom: 0;
         width: 0.5em;
         height: 1em;
-        margin-left: 1px;
-        vertical-align: text-bottom;
         background: var(--accent);
         animation: type-blink 1s steps(2, start) infinite;
     }
 
-    .type-cursor.is-done {
+    .type-cursor.is-done::after {
         animation: none;
         opacity: 0;
         transition: opacity var(--dur-base) var(--ease-standard);
@@ -151,7 +165,7 @@ const education = (await getCollection('education')).sort(
     }
 
     @media (prefers-reduced-motion: reduce) {
-        .type-cursor {
+        .type-cursor::after {
             animation: none;
         }
     }
@@ -342,7 +356,8 @@ const education = (await getCollection('education')).sort(
                     end: inside.length ? inside[inside.length - 1].end : 0
                 };
             });
-            return {nodes: nodes, blocks: blocks, total: offset, cut: offset, cursor: null, raf: 0, typing: false};
+            return {nodes: nodes, blocks: blocks, total: offset, cut: offset, cursor: null, raf: 0,
+                    growTimer: 0, typing: false};
         };
 
         /* Restore text up to character `upto`; empty everything after. Returns the last
@@ -443,6 +458,8 @@ const education = (await getCollection('education')).sort(
 
         const finish = (story) => {
             const s = state.get(story);
+            if (s.growTimer) clearTimeout(s.growTimer);
+            s.growTimer = 0;
             if (s.raf) cancelAnimationFrame(s.raf);
             s.raf = 0;
             s.typing = false;
@@ -537,11 +554,22 @@ const education = (await getCollection('education')).sort(
             void story.offsetHeight;
             story.style.minHeight = fullHeight + 'px';
 
-            setTimeout(() => type(story), GROW_MS);
+            /* Cancel any grow timer still pending from a previous expand. Without this, a
+               fast expand -> collapse -> expand inside the 340ms grow window leaves a stale
+               timeout that fires type() a second time, and two rAF loops then race over the
+               same story sharing s.raf/s.cursor with last-write-wins — orphaning one loop
+               forever. Reproduced: three quick clicks produced two live cursors. */
+            if (s.growTimer) clearTimeout(s.growTimer);
+            s.growTimer = setTimeout(() => {
+                s.growTimer = 0;
+                type(story);
+            }, GROW_MS);
         };
 
         const collapse = (story, button) => {
             const s = state.get(story);
+            if (s.growTimer) clearTimeout(s.growTimer); /* a run scheduled but not yet started */
+            s.growTimer = 0;
             if (s.raf) cancelAnimationFrame(s.raf);
             s.raf = 0;
             s.typing = false;

--- a/src/pages/about.astro
+++ b/src/pages/about.astro
@@ -42,9 +42,14 @@ const education = (await getCollection('education')).sort(
             <p class='kicker mb-4'>
                 <span class='cue-back'>Today → 2019</span><span class='cue-forward'>2019 → Today</span> · {experiences.length} roles
             </p>
-            <h2 class='font-display text-4xl md:text-[44px] font-semibold text-strong leading-tight mb-12'>
+            <h2 class='font-display text-4xl md:text-[44px] font-semibold text-strong leading-tight mb-6'>
                 The story behind my experience.
             </h2>
+            <div class='flex items-center gap-2 mb-12' id='orderControl'>
+                <span class='kicker'>Read</span>
+                <button type='button' class='order-btn chip' data-order='latest' aria-pressed='true'>Latest first</button>
+                <button type='button' class='order-btn chip' data-order='story' aria-pressed='false'>Story order</button>
+            </div>
             <div class='relative' id='experienceTimeline'>
                 <div id='timelineLine' class='absolute left-[13px] md:left-[23px] w-[2px] bg-hairline' aria-hidden='true'></div>
                 <div id='timelineMarker'
@@ -103,6 +108,16 @@ const education = (await getCollection('education')).sort(
        handles both without position logic. */
     .timeline-entry:first-child .direction-cue {
         display: none;
+    }
+
+    .order-btn {
+        cursor: pointer;
+    }
+
+    .order-btn[aria-pressed='true'] {
+        background: var(--accent-wash);
+        color: var(--text-strong);
+        font-weight: 600;
     }
 
     .timeline-entry .story-card {

--- a/src/pages/about.astro
+++ b/src/pages/about.astro
@@ -104,9 +104,10 @@ const education = (await getCollection('education')).sort(
         display: inline;
     }
 
-    /* The leading card has nothing before it — true in either order, so :first-child
-       handles both without position logic. */
-    .timeline-entry:first-child .direction-cue {
+    /* The leading card has nothing before it. The marker is always the node
+       immediately before it — in the SSR'd HTML and after any reorder — so this
+       matches in both orders with no position logic. */
+    #timelineMarker + .timeline-entry .direction-cue {
         display: none;
     }
 

--- a/src/pages/about.astro
+++ b/src/pages/about.astro
@@ -45,8 +45,8 @@ const education = (await getCollection('education')).sort(
             <h2 class='font-display text-4xl md:text-[44px] font-semibold text-strong leading-tight mb-6'>
                 The story behind my experience.
             </h2>
-            <div class='flex items-center gap-2 mb-12' id='orderControl'>
-                <span class='kicker'>Read</span>
+            <div class='flex items-center gap-2 mb-12' id='orderControl' role='group' aria-labelledby='orderControlLabel'>
+                <span class='kicker' id='orderControlLabel'>Read</span>
                 <button type='button' class='order-btn chip' data-order='latest' aria-pressed='true'>Latest first</button>
                 <button type='button' class='order-btn chip' data-order='story' aria-pressed='false'>Story order</button>
             </div>

--- a/src/pages/about.astro
+++ b/src/pages/about.astro
@@ -127,6 +127,35 @@ const education = (await getCollection('education')).sort(
         font-weight: 600;
     }
 
+    /* The cursor is created by script, so it cannot live in ExperienceCard's scoped styles. */
+    .type-cursor {
+        display: inline-block;
+        width: 0.5em;
+        height: 1em;
+        margin-left: 1px;
+        vertical-align: text-bottom;
+        background: var(--accent);
+        animation: type-blink 1s steps(2, start) infinite;
+    }
+
+    .type-cursor.is-done {
+        animation: none;
+        opacity: 0;
+        transition: opacity var(--dur-base) var(--ease-standard);
+    }
+
+    @keyframes type-blink {
+        to {
+            visibility: hidden;
+        }
+    }
+
+    @media (prefers-reduced-motion: reduce) {
+        .type-cursor {
+            animation: none;
+        }
+    }
+
     .timeline-entry .story-card {
         /* Anchor the left edge so the gap to the timeline rail never changes */
         transform-origin: left center;
@@ -282,6 +311,10 @@ const education = (await getCollection('education')).sort(
     if (!window.__storyRevealBound) {
         window.__storyRevealBound = true;
 
+        const D_TARGET = 12;       /* ms/char: the steady writing rate we aim for */
+        const CEILING = 6000;      /* ms: hard ceiling on one reveal, no matter how long */
+        const MAX_FRAME_MS = 50;   /* clamp a stalled frame so it cannot dump the story */
+        const GROW_MS = 340;       /* the .story min-height transition is 320ms */
         const LINES = 3;   /* collapsed height, matching the 77px clamp this replaces */
 
         const state = new WeakMap();
@@ -408,15 +441,109 @@ const education = (await getCollection('education')).sort(
             }
         };
 
+        const finish = (story) => {
+            const s = state.get(story);
+            if (s.raf) cancelAnimationFrame(s.raf);
+            s.raf = 0;
+            s.typing = false;
+            reveal(story, s.total);
+            story.style.minHeight = '';
+            if (s.cursor) {
+                const cursor = s.cursor;
+                s.cursor = null;
+                cursor.classList.add('is-done');
+                setTimeout(() => cursor.remove(), 260);
+            }
+        };
+
+        const placeCursor = (story, upto) => {
+            const s = state.get(story);
+            if (!s.cursor) return;
+            let tail = s.nodes[0];
+            for (const item of s.nodes) if (item.start < upto) tail = item;
+            const parent = tail.node.parentNode;
+            if (parent && s.cursor.previousSibling !== tail.node) {
+                parent.insertBefore(s.cursor, tail.node.nextSibling);
+            }
+        };
+
+        const type = (story) => {
+            const s = state.get(story);
+            /* The reader may have collapsed the card during the grow delay. */
+            if (story.classList.contains('collapsed')) return;
+            const from = s.cut;
+            const N = s.total - from;
+            if (N <= 0) {
+                finish(story);
+                return;
+            }
+
+            /* delay ramps dFast -> dSteady across the first third, then holds constant.
+               Integrating that gives T = 11*N*dSteady/12, hence dSteady = 12T/(11N).
+               Under the ceiling, dSteady resolves to exactly D_TARGET. */
+            const T = Math.min(CEILING, (11 * N * D_TARGET) / 12);
+            const dSteady = (12 * T) / (11 * N);
+            const dFast = dSteady / 2;
+            const delayAt = (i) => dFast + (dSteady - dFast) * Math.min(1, (i / N) * 3);
+
+            s.cursor = document.createElement('span');
+            s.cursor.className = 'type-cursor';
+            s.cursor.setAttribute('aria-hidden', 'true');
+            s.typing = true;
+
+            let revealed = from;
+            let acc = 0;
+            let last = performance.now();
+            const frame = (now) => {
+                acc += Math.min(now - last, MAX_FRAME_MS);
+                last = now;
+                while (revealed < s.total && acc >= delayAt(revealed - from)) {
+                    acc -= delayAt(revealed - from);
+                    revealed++;
+                }
+                reveal(story, revealed);
+                placeCursor(story, revealed);
+                if (revealed >= s.total) {
+                    finish(story);
+                    return;
+                }
+                s.raf = requestAnimationFrame(frame);
+            };
+            s.raf = requestAnimationFrame(frame);
+        };
+
         const expand = (story, button) => {
             const s = state.get(story);
             story.classList.remove('collapsed');
             button.textContent = 'Show less ↑';
             button.setAttribute('aria-expanded', 'true');
+
+            /* Measure the full height by briefly revealing everything. This is synchronous
+               and forces one reflow, so the browser never paints the revealed state. */
             reveal(story, s.total);
+            const fullHeight = story.scrollHeight;
+            reveal(story, s.cut, true);
+
+            /* Reserve the space before typing so nothing below the card shifts while the
+               reader reads. min-height needs an explicit start value — auto will not
+               transition. */
+            story.style.minHeight = story.offsetHeight + 'px';
+            void story.offsetHeight;
+            story.style.minHeight = fullHeight + 'px';
+
+            setTimeout(() => type(story), GROW_MS);
         };
 
         const collapse = (story, button) => {
+            const s = state.get(story);
+            if (s.raf) cancelAnimationFrame(s.raf);
+            s.raf = 0;
+            s.typing = false;
+            if (s.cursor) {
+                s.cursor.remove();
+                s.cursor = null;
+            }
+            story.style.minHeight = '';
             story.classList.add('collapsed');
             button.textContent = 'Read the story ↓';
             button.setAttribute('aria-expanded', 'false');

--- a/src/pages/about.astro
+++ b/src/pages/about.astro
@@ -104,6 +104,10 @@ const education = (await getCollection('education')).sort(
         display: inline;
     }
 
+    .order-story #timelineFlashback {
+        display: none;
+    }
+
     /* The leading card has nothing before it. The marker is always the node
        immediately before it — in the SSR'd HTML and after any reorder — so this
        matches in both orders with no position logic. */
@@ -119,10 +123,6 @@ const education = (await getCollection('education')).sort(
         background: var(--accent-wash);
         color: var(--text-strong);
         font-weight: 600;
-    }
-
-    .order-story #timelineFlashback {
-        display: none;
     }
 
     .timeline-entry .story-card {
@@ -234,8 +234,9 @@ const education = (await getCollection('education')).sort(
             // querySelectorAll order with offsetTop and would desync otherwise.
             ordered.forEach((entry) => timeline.appendChild(entry));
 
-            // The flashback frame only makes sense walking backwards; in story order
-            // the current role is last, so it is hidden by CSS and its position is moot.
+            // The re-append strands the flashback at the front, so re-seat it after
+            // the leading entry. In story order that lands it mid-list, which is moot —
+            // CSS hides it there.
             if (flashback) timeline.insertBefore(flashback, ordered[1] ?? null);
 
             section.classList.toggle('order-story', order === 'story');
@@ -257,9 +258,9 @@ const education = (await getCollection('education')).sort(
         };
 
         document.addEventListener('click', (event) => {
-            const button = event.target?.closest?.('.order-btn');
+            const button = event.target?.closest('.order-btn');
             if (!button) return;
-            const order = button.dataset.order;
+            const order = button.dataset.order === 'story' ? 'story' : 'latest';
             try {
                 localStorage.setItem(STORAGE_KEY, order);
             } catch {
@@ -268,7 +269,9 @@ const education = (await getCollection('education')).sort(
             applyOrder(order);
         });
 
-        // Re-apply on first load and after each View Transitions navigation.
-        document.addEventListener('astro:page-load', () => applyOrder(readStoredOrder()));
+        // Runs before paint to avoid a flash of the wrong order; astro:after-swap
+        // covers View Transitions navigations, matching how theme setup does it.
+        applyOrder(readStoredOrder());
+        document.addEventListener('astro:after-swap', () => applyOrder(readStoredOrder()));
     }
 </script>

--- a/src/pages/about.astro
+++ b/src/pages/about.astro
@@ -360,20 +360,28 @@ const education = (await getCollection('education')).sort(
                     growTimer: 0, typing: false};
         };
 
-        /* Restore text up to character `upto`; empty everything after. Returns the last
-           node holding revealed text, which is where the cursor goes. */
+        /* Restore text up to character `upto`; empty everything after. Returns the last node
+           holding revealed, non-whitespace text — the anchor for both the ellipsis and the
+           cursor.
+
+           Whitespace-only nodes MUST be skipped. Markdown renders `<p>…</p>\n<p>…</p>`, so
+           the `\n` between paragraphs is a text node whose parent is the `.story` div, not a
+           paragraph. Anchoring to it puts the cursor in BLOCK context, which forces an
+           anonymous block box costing a full line-height (measured +25.56px), and would put
+           the ellipsis on a newline node. */
         const reveal = (story, upto, ellipsis) => {
             const s = state.get(story);
             let tail = null;
             for (const item of s.nodes) {
                 if (item.end <= upto) {
                     if (item.node.nodeValue !== item.full) item.node.nodeValue = item.full;
-                    if (item.full.length) tail = item;
+                    if (item.full.trim()) tail = item;
                 } else if (item.start >= upto) {
                     if (item.node.nodeValue !== '') item.node.nodeValue = '';
                 } else {
-                    item.node.nodeValue = item.full.slice(0, upto - item.start);
-                    tail = item;
+                    const shown = item.full.slice(0, upto - item.start);
+                    item.node.nodeValue = shown;
+                    if (shown.trim()) tail = item;
                 }
             }
             for (const b of s.blocks) {
@@ -473,11 +481,12 @@ const education = (await getCollection('education')).sort(
             }
         };
 
-        const placeCursor = (story, upto) => {
+        /* Takes the tail `reveal` already computed. Do not re-derive it here: a second scan
+           with slightly different rules is a second definition of "the tail" that can drift
+           out of agreement, and it costs an extra O(n) pass every frame. */
+        const placeCursor = (story, tail) => {
             const s = state.get(story);
-            if (!s.cursor) return;
-            let tail = s.nodes[0];
-            for (const item of s.nodes) if (item.start < upto) tail = item;
+            if (!s.cursor || !tail) return;
             const parent = tail.node.parentNode;
             if (parent && s.cursor.previousSibling !== tail.node) {
                 parent.insertBefore(s.cursor, tail.node.nextSibling);
@@ -518,8 +527,7 @@ const education = (await getCollection('education')).sort(
                     acc -= delayAt(revealed - from);
                     revealed++;
                 }
-                reveal(story, revealed);
-                placeCursor(story, revealed);
+                placeCursor(story, reveal(story, revealed));
                 if (revealed >= s.total) {
                     finish(story);
                     return;
@@ -558,9 +566,11 @@ const education = (await getCollection('education')).sort(
                06-teknika-backend-lead, and 0.98-1.02 line-heights across all eight stories,
                which is what makes one line a safe bound.
 
-               The cursor is NOT the cause here: it is width:0 with an absolutely-positioned
-               ::after and measures 0x0, verified layout-neutral. Do not "fix" this by
-               padding for the cursor.
+               The cursor is not the cause: it is width:0 with an absolutely-positioned
+               ::after. (Its own rect measures 0x0, but note that measuring the cursor's rect
+               cannot detect the case where it lands in block context — `reveal` skipping
+               whitespace-only nodes is what prevents that.) Do not "fix" this by padding for
+               the cursor.
 
                min-height needs an explicit start value — auto will not transition. */
             const lineHeight = parseFloat(getComputedStyle(story).lineHeight) || 0;
@@ -628,6 +638,10 @@ const education = (await getCollection('education')).sort(
         }, {threshold: 0});
 
         const initStories = () => {
+            /* IntersectionObserver holds STRONG references to its targets, and View
+               Transitions replace the cards on every navigation — without this, each return
+               to /about leaks the previous set. */
+            offscreenObserver.disconnect();
             document.querySelectorAll('.story').forEach((story) => {
                 if (!state.has(story)) state.set(story, buildState(story));
                 if (story.classList.contains('collapsed')) truncate(story);
@@ -636,6 +650,19 @@ const education = (await getCollection('education')).sort(
         };
         initStories();
         document.addEventListener('astro:after-swap', initStories);
+
+        /* The cut is measured against a specific box width, so it goes stale the moment the
+           box changes width — window snap, phone rotation, zoom, devtools. The old
+           `max-height: 77px` clamp was viewport-independent and could not fail this way;
+           `.collapsed` now carries no CSS at all, so nothing else catches it. Measured
+           without this: resizing 1600px -> 760px rendered collapsed cards at up to 6 lines
+           instead of 3. initStories is idempotent and only re-cuts collapsed stories, so an
+           expanded or mid-run card is left alone. */
+        let resizeTimer = 0;
+        window.addEventListener('resize', () => {
+            clearTimeout(resizeTimer);
+            resizeTimer = setTimeout(initStories, 150);
+        }, {passive: true});
 
         /* The pre-paint pass measures with fallback font metrics, so the boundary is wrong
            until the web fonts swap in. Re-truncate once they land. The page already

--- a/src/pages/about.astro
+++ b/src/pages/about.astro
@@ -108,10 +108,12 @@ const education = (await getCollection('education')).sort(
         display: none;
     }
 
-    /* The leading card has nothing before it. The marker is always the node
-       immediately before it — in the SSR'd HTML and after any reorder — so this
-       matches in both orders with no position logic. */
-    #timelineMarker + .timeline-entry .direction-cue {
+    /* The leading card has nothing before it. "Not preceded by another entry"
+       is true of whichever card leads, in either order, and is immune to the
+       rail divs, the flashback, and the script Vite injects between them in dev.
+       Do not narrow this to :first-child or an adjacent-sibling form — both
+       assume a fixed node layout and silently match nothing. */
+    .timeline-entry:not(.timeline-entry ~ .timeline-entry) .direction-cue {
         display: none;
     }
 

--- a/src/pages/about.astro
+++ b/src/pages/about.astro
@@ -335,13 +335,17 @@ const education = (await getCollection('education')).sort(
             return tail;
         };
 
-        /* Top of the character at `index`, or null if it has no box (collapsed whitespace). */
+        /* Top of the character at `index`, or null if it has no box (collapsed whitespace)
+           or has not been revealed yet. The length guard matters: after a cut, nodes past
+           the cut hold '', and setStart past a node's length throws IndexSizeError. */
         const rectTopAt = (s, index) => {
             for (const item of s.nodes) {
                 if (index >= item.start && index < item.end) {
+                    const offset = index - item.start;
+                    if (offset + 1 > item.node.nodeValue.length) return null;
                     const range = document.createRange();
-                    range.setStart(item.node, index - item.start);
-                    range.setEnd(item.node, index - item.start + 1);
+                    range.setStart(item.node, offset);
+                    range.setEnd(item.node, offset + 1);
                     const rect = range.getBoundingClientRect();
                     return rect.height ? rect.top : null;
                 }
@@ -349,20 +353,21 @@ const education = (await getCollection('education')).sort(
             return null;
         };
 
-        /* First character index that falls below `lines` lines. Binary search, not a linear
-           walk: tops increase monotonically down the flow, so this costs ~11 probes per
-           story instead of ~2000. Nothing is mutated during the search, so the layout read
-           stays cached. */
-        const lineBoundary = (story, lines) => {
+        /* First character index that falls below `lines` lines, searching only up to
+           `hiBound`. Binary search, not a linear walk: tops increase monotonically down the
+           flow, so this costs ~11 probes per story instead of ~2000. Nothing is mutated
+           during the search, so the layout read stays cached. */
+        const lineBoundary = (story, lines, hiBound) => {
             const s = state.get(story);
             const lineHeight = parseFloat(getComputedStyle(story).lineHeight);
             if (!lineHeight) return s.total;
+            const limitIndex = Math.min(hiBound === undefined ? s.total : hiBound, s.total);
             let firstTop = null;
-            for (let i = 0; i < s.total && firstTop === null; i++) firstTop = rectTopAt(s, i);
-            if (firstTop === null) return s.total;
+            for (let i = 0; i < limitIndex && firstTop === null; i++) firstTop = rectTopAt(s, i);
+            if (firstTop === null) return limitIndex;
             const limit = firstTop + lines * lineHeight - 1;
             let lo = 0;
-            let hi = s.total;
+            let hi = limitIndex;
             while (lo < hi) {
                 const mid = (lo + hi) >> 1;
                 const top = rectTopAt(s, mid);
@@ -375,15 +380,32 @@ const education = (await getCollection('education')).sort(
         const truncate = (story) => {
             const s = state.get(story);
             reveal(story, s.total); /* measure against the full text */
-            const boundary = lineBoundary(story, LINES);
+            const full = s.nodes.map((n) => n.full).join('');
+            const backOff = (index) => {
+                const space = full.slice(0, index).lastIndexOf(' ');
+                return space > 0 ? space : index;
+            };
+
+            const boundary = lineBoundary(story, LINES, s.total);
             if (boundary >= s.total) {
                 s.cut = s.total;
                 return;
             }
-            const full = s.nodes.map((n) => n.full).join('');
-            const space = full.slice(0, boundary).lastIndexOf(' ');
-            s.cut = space > 0 ? space : boundary;
+            s.cut = backOff(boundary);
             reveal(story, s.cut, true);
+
+            /* global.css sets `p { text-wrap: pretty }`, which rebalances a paragraph's
+               line breaks across its WHOLE content. Line breaking is therefore not greedy:
+               cutting text changes how the text that remains wraps, so a boundary measured
+               against the full story can render one line too tall once applied. Measure
+               what was actually rendered and tighten until it fits. Converges in 1-2
+               passes; the bound stops it probing the emptied nodes past the cut. */
+            for (let pass = 0; pass < 4; pass++) {
+                const rendered = lineBoundary(story, LINES, s.cut);
+                if (rendered >= s.cut) break;
+                s.cut = backOff(rendered);
+                reveal(story, s.cut, true);
+            }
         };
 
         const expand = (story, button) => {

--- a/src/pages/about.astro
+++ b/src/pages/about.astro
@@ -142,47 +142,53 @@ const education = (await getCollection('education')).sort(
        `.story.collapsed + .story-toggle` matches only while there is something left to
        read — so the current role, expanded on load showing "Show less ↑", never shimmers.
        Only one card is ever active, so only one button ever glints. */
+    /* The glint runs THROUGH the letterforms, not behind them — a wash on a padded box reads
+       as a highlighted rectangle, not a shimmer.
+
+       The glint is caramel mixed toward --text-strong, and that token is what makes this
+       work: it flips per theme (choc ink on cream, cream on navy), so the mix automatically
+       moves AWAY from the background in both — darker on light, lighter on dark. Pure
+       --accent cannot be used as text here: measured against the card surface it is 3.69:1
+       in light and 3.37:1 in dark, both under the 4.5:1 AA floor, because caramel is a
+       mid-tone that is low-contrast on cream AND on navy. At 70% the mix measures 5.74:1
+       light / 4.92:1 dark. 80% already fails dark at 4.33:1 — do not push it warmer. */
     .timeline-entry.is-active .story.collapsed + .story-toggle {
-        position: relative;
-        isolation: isolate;
-    }
-
-    /* The wash sweeps BEHIND the label, not through it.
-
-       Caramel cannot be a text colour here. Measured against the card surface, --accent is
-       3.69:1 in light and 3.37:1 in dark — both under the 4.5:1 AA floor — and dark mode's
-       --info base is already only 4.53:1, so there is no headroom to tint toward caramel at
-       all. Caramel is a mid-tone: low contrast on cream AND on navy. That is exactly why the
-       design system uses it for the rail dot (a shape) and as --accent-wash (a background),
-       never as text. Sweeping the wash underneath keeps the label at full --info contrast
-       (7.91 light / 4.53 dark) while still reading as a warm caramel glint. */
-    .timeline-entry.is-active .story.collapsed + .story-toggle::before {
-        content: '';
-        position: absolute;
-        inset: -2px -6px;
-        z-index: -1;
-        border-radius: 4px;
         background-image: linear-gradient(100deg,
-            transparent 40%, var(--accent-wash) 50%, transparent 60%);
-        background-size: 300% 100%;
+            var(--info) 40%,
+            color-mix(in srgb, var(--accent) 70%, var(--text-strong)) 50%,
+            var(--info) 60%);
+        background-size: 250% 100%;
         background-repeat: no-repeat;
-        animation: toggle-glint 4s var(--ease-standard) infinite;
+        -webkit-background-clip: text;
+        background-clip: text;
+        color: transparent;
+        animation: toggle-glint 5s linear infinite;
     }
 
-    /* Sweep across the first 30% (~1.2s), then rest. A continuous shimmer would sit in the
-       exact spot the reader is reading — the card is active because their eyes are there. */
+    /* Sweep across the first 45% (~2.25s), then rest ~2.75s. A continuous shimmer would sit
+       in the exact spot the reader is reading, since the card is active precisely because
+       their eyes are there.
+
+       `linear`, deliberately, NOT --ease-standard. That token is an ease-out, and easing the
+       whole animation front-loads the travel: measured, it covered most of its distance in
+       the first 500ms and then crawled — a blink, then nothing. A traveling band has to move
+       at constant speed to read as a sweep. Easing is for transitions, not for this. */
     @keyframes toggle-glint {
         0% {
             background-position: 150% 0;
         }
-        30%, 100% {
+        45%, 100% {
             background-position: -150% 0;
         }
     }
 
     @media (prefers-reduced-motion: reduce) {
-        .timeline-entry.is-active .story.collapsed + .story-toggle::before {
-            content: none;
+        .timeline-entry.is-active .story.collapsed + .story-toggle {
+            background-image: none;
+            animation: none;
+            /* must be restored — background-clip:text with a transparent colour would
+               otherwise leave the label invisible */
+            color: var(--info);
         }
     }
 

--- a/src/pages/about.astro
+++ b/src/pages/about.astro
@@ -38,8 +38,10 @@ const education = (await getCollection('education')).sort(
 
     <!-- Experience timeline -->
     <section class='border-t border-hairline'>
-        <div class='shell py-[72px]'>
-            <p class='kicker mb-4'>2019 → Today · {experiences.length} roles</p>
+        <div class='shell py-[72px]' id='experienceSection'>
+            <p class='kicker mb-4'>
+                <span class='cue-back'>Today → 2019</span><span class='cue-forward'>2019 → Today</span> · {experiences.length} roles
+            </p>
             <h2 class='font-display text-4xl md:text-[44px] font-semibold text-strong leading-tight mb-12'>
                 The story behind my experience.
             </h2>
@@ -73,6 +75,20 @@ const education = (await getCollection('education')).sort(
 </BaseLayout>
 
 <style is:global>
+    /* Direction-dependent text is rendered twice; .order-story picks which shows.
+       This keeps the Phase 2 toggle to a single class flip — no string rewriting. */
+    .cue-forward {
+        display: none;
+    }
+
+    .order-story .cue-back {
+        display: none;
+    }
+
+    .order-story .cue-forward {
+        display: inline;
+    }
+
     .timeline-entry .story-card {
         /* Anchor the left edge so the gap to the timeline rail never changes */
         transform-origin: left center;

--- a/src/pages/about.astro
+++ b/src/pages/about.astro
@@ -277,3 +277,154 @@ const education = (await getCollection('education')).sort(
         document.addEventListener('astro:after-swap', () => applyOrder(readStoredOrder()));
     }
 </script>
+
+<script is:inline>
+    if (!window.__storyRevealBound) {
+        window.__storyRevealBound = true;
+
+        const LINES = 3;   /* collapsed height, matching the 77px clamp this replaces */
+
+        const state = new WeakMap();
+
+        /* Flat character map over the story's text nodes. Walking text nodes (rather than
+           slicing innerHTML) is what keeps <strong> and the bullet list in 09-solo-engineer
+           intact. */
+        const buildState = (story) => {
+            const walker = document.createTreeWalker(story, NodeFilter.SHOW_TEXT);
+            const nodes = [];
+            let offset = 0;
+            let node;
+            while ((node = walker.nextNode())) {
+                const full = node.nodeValue || '';
+                nodes.push({node: node, full: full, start: offset, end: offset + full.length});
+                offset += full.length;
+            }
+            /* Blocks that leave an artefact when emptied: an empty <p> still occupies a
+               line, an empty <li> still paints its bullet via li::before. */
+            const blocks = Array.from(story.querySelectorAll('p, ul, ol, li')).map((el) => {
+                const inside = nodes.filter((n) => el.contains(n.node));
+                return {
+                    el: el,
+                    start: inside.length ? inside[0].start : 0,
+                    end: inside.length ? inside[inside.length - 1].end : 0
+                };
+            });
+            return {nodes: nodes, blocks: blocks, total: offset, cut: offset, cursor: null, raf: 0, typing: false};
+        };
+
+        /* Restore text up to character `upto`; empty everything after. Returns the last
+           node holding revealed text, which is where the cursor goes. */
+        const reveal = (story, upto, ellipsis) => {
+            const s = state.get(story);
+            let tail = null;
+            for (const item of s.nodes) {
+                if (item.end <= upto) {
+                    if (item.node.nodeValue !== item.full) item.node.nodeValue = item.full;
+                    if (item.full.length) tail = item;
+                } else if (item.start >= upto) {
+                    if (item.node.nodeValue !== '') item.node.nodeValue = '';
+                } else {
+                    item.node.nodeValue = item.full.slice(0, upto - item.start);
+                    tail = item;
+                }
+            }
+            for (const b of s.blocks) {
+                b.el.style.display = b.start >= upto && b.end > b.start ? 'none' : '';
+            }
+            if (ellipsis && tail) tail.node.nodeValue = tail.node.nodeValue + '…';
+            return tail;
+        };
+
+        /* Top of the character at `index`, or null if it has no box (collapsed whitespace). */
+        const rectTopAt = (s, index) => {
+            for (const item of s.nodes) {
+                if (index >= item.start && index < item.end) {
+                    const range = document.createRange();
+                    range.setStart(item.node, index - item.start);
+                    range.setEnd(item.node, index - item.start + 1);
+                    const rect = range.getBoundingClientRect();
+                    return rect.height ? rect.top : null;
+                }
+            }
+            return null;
+        };
+
+        /* First character index that falls below `lines` lines. Binary search, not a linear
+           walk: tops increase monotonically down the flow, so this costs ~11 probes per
+           story instead of ~2000. Nothing is mutated during the search, so the layout read
+           stays cached. */
+        const lineBoundary = (story, lines) => {
+            const s = state.get(story);
+            const lineHeight = parseFloat(getComputedStyle(story).lineHeight);
+            if (!lineHeight) return s.total;
+            let firstTop = null;
+            for (let i = 0; i < s.total && firstTop === null; i++) firstTop = rectTopAt(s, i);
+            if (firstTop === null) return s.total;
+            const limit = firstTop + lines * lineHeight - 1;
+            let lo = 0;
+            let hi = s.total;
+            while (lo < hi) {
+                const mid = (lo + hi) >> 1;
+                const top = rectTopAt(s, mid);
+                if (top === null || top <= limit) lo = mid + 1;
+                else hi = mid;
+            }
+            return lo;
+        };
+
+        const truncate = (story) => {
+            const s = state.get(story);
+            reveal(story, s.total); /* measure against the full text */
+            const boundary = lineBoundary(story, LINES);
+            if (boundary >= s.total) {
+                s.cut = s.total;
+                return;
+            }
+            const full = s.nodes.map((n) => n.full).join('');
+            const space = full.slice(0, boundary).lastIndexOf(' ');
+            s.cut = space > 0 ? space : boundary;
+            reveal(story, s.cut, true);
+        };
+
+        const expand = (story, button) => {
+            const s = state.get(story);
+            story.classList.remove('collapsed');
+            button.textContent = 'Show less ↑';
+            button.setAttribute('aria-expanded', 'true');
+            reveal(story, s.total);
+        };
+
+        const collapse = (story, button) => {
+            story.classList.add('collapsed');
+            button.textContent = 'Read the story ↓';
+            button.setAttribute('aria-expanded', 'false');
+            truncate(story);
+        };
+
+        document.addEventListener('click', (event) => {
+            const button = event.target?.closest('.story-toggle');
+            if (!button) return;
+            const story = button.closest('.story-card')?.querySelector('.story');
+            if (!story || !state.has(story)) return;
+            if (story.classList.contains('collapsed')) expand(story, button);
+            else collapse(story, button);
+        });
+
+        /* Runs before paint so the full story never flashes; astro:after-swap covers
+           View Transitions navigations, matching the other scripts on this page. */
+        const initStories = () => {
+            document.querySelectorAll('.story').forEach((story) => {
+                if (!state.has(story)) state.set(story, buildState(story));
+                if (story.classList.contains('collapsed')) truncate(story);
+            });
+        };
+        initStories();
+        document.addEventListener('astro:after-swap', initStories);
+
+        /* The pre-paint pass measures with fallback font metrics, so the boundary is wrong
+           until the web fonts swap in. Re-truncate once they land. The page already
+           reflows on font swap, so this rides along invisibly. Only collapsed stories are
+           re-cut, so a story the reader already expanded is left alone. */
+        if (document.fonts && document.fonts.ready) document.fonts.ready.then(initStories);
+    }
+</script>

--- a/src/pages/about.astro
+++ b/src/pages/about.astro
@@ -135,6 +135,57 @@ const education = (await getCollection('education')).sort(
        reserved before it existed, which is the exact layout shift the grow-then-type
        sequence exists to prevent. Measured: reserved 497px vs 522px actual. The block is
        therefore painted by an absolutely-positioned ::after, which is outside the flow. */
+    /* An occasional caramel glint through the toggle, inviting the reader in.
+
+       Scoped by two classes that already exist, so this needs no JavaScript:
+       `.is-active` is set by the rail script on the card the traveling dot is on, and
+       `.story.collapsed + .story-toggle` matches only while there is something left to
+       read — so the current role, expanded on load showing "Show less ↑", never shimmers.
+       Only one card is ever active, so only one button ever glints. */
+    .timeline-entry.is-active .story.collapsed + .story-toggle {
+        position: relative;
+        isolation: isolate;
+    }
+
+    /* The wash sweeps BEHIND the label, not through it.
+
+       Caramel cannot be a text colour here. Measured against the card surface, --accent is
+       3.69:1 in light and 3.37:1 in dark — both under the 4.5:1 AA floor — and dark mode's
+       --info base is already only 4.53:1, so there is no headroom to tint toward caramel at
+       all. Caramel is a mid-tone: low contrast on cream AND on navy. That is exactly why the
+       design system uses it for the rail dot (a shape) and as --accent-wash (a background),
+       never as text. Sweeping the wash underneath keeps the label at full --info contrast
+       (7.91 light / 4.53 dark) while still reading as a warm caramel glint. */
+    .timeline-entry.is-active .story.collapsed + .story-toggle::before {
+        content: '';
+        position: absolute;
+        inset: -2px -6px;
+        z-index: -1;
+        border-radius: 4px;
+        background-image: linear-gradient(100deg,
+            transparent 40%, var(--accent-wash) 50%, transparent 60%);
+        background-size: 300% 100%;
+        background-repeat: no-repeat;
+        animation: toggle-glint 4s var(--ease-standard) infinite;
+    }
+
+    /* Sweep across the first 30% (~1.2s), then rest. A continuous shimmer would sit in the
+       exact spot the reader is reading — the card is active because their eyes are there. */
+    @keyframes toggle-glint {
+        0% {
+            background-position: 150% 0;
+        }
+        30%, 100% {
+            background-position: -150% 0;
+        }
+    }
+
+    @media (prefers-reduced-motion: reduce) {
+        .timeline-entry.is-active .story.collapsed + .story-toggle::before {
+            content: none;
+        }
+    }
+
     .type-cursor {
         position: relative;
         display: inline-block;
@@ -329,8 +380,6 @@ const education = (await getCollection('education')).sort(
         const CEILING = 6000;      /* ms: hard ceiling on one reveal, no matter how long */
         const MAX_FRAME_MS = 50;   /* clamp a stalled frame so it cannot dump the story */
         const GROW_MS = 340;       /* the .story min-height transition is 320ms */
-        const LINES = 3;   /* collapsed height, matching the 77px clamp this replaces */
-
         const state = new WeakMap();
 
         /* Flat character map over the story's text nodes. Walking text nodes (rather than
@@ -361,15 +410,13 @@ const education = (await getCollection('education')).sort(
         };
 
         /* Restore text up to character `upto`; empty everything after. Returns the last node
-           holding revealed, non-whitespace text — the anchor for both the ellipsis and the
-           cursor.
+           holding revealed, non-whitespace text — the anchor for the cursor.
 
            Whitespace-only nodes MUST be skipped. Markdown renders `<p>…</p>\n<p>…</p>`, so
            the `\n` between paragraphs is a text node whose parent is the `.story` div, not a
            paragraph. Anchoring to it puts the cursor in BLOCK context, which forces an
-           anonymous block box costing a full line-height (measured +25.56px), and would put
-           the ellipsis on a newline node. */
-        const reveal = (story, upto, ellipsis) => {
+           anonymous block box costing a full line-height (measured +25.56px). */
+        const reveal = (story, upto) => {
             const s = state.get(story);
             let tail = null;
             for (const item of s.nodes) {
@@ -387,81 +434,31 @@ const education = (await getCollection('education')).sort(
             for (const b of s.blocks) {
                 b.el.style.display = b.start >= upto && b.end > b.start ? 'none' : '';
             }
-            if (ellipsis && tail) tail.node.nodeValue = tail.node.nodeValue + '…';
             return tail;
         };
 
-        /* Top of the character at `index`, or null if it has no box (collapsed whitespace)
-           or has not been revealed yet. The length guard matters: after a cut, nodes past
-           the cut hold '', and setStart past a node's length throws IndexSizeError. */
-        const rectTopAt = (s, index) => {
-            for (const item of s.nodes) {
-                if (index >= item.start && index < item.end) {
-                    const offset = index - item.start;
-                    if (offset + 1 > item.node.nodeValue.length) return null;
-                    const range = document.createRange();
-                    range.setStart(item.node, offset);
-                    range.setEnd(item.node, offset + 1);
-                    const rect = range.getBoundingClientRect();
-                    return rect.height ? rect.top : null;
-                }
-            }
-            return null;
-        };
+        /* The teaser is the first block — a whole paragraph, a complete thought.
 
-        /* First character index that falls below `lines` lines, searching only up to
-           `hiBound`. Binary search, not a linear walk: tops increase monotonically down the
-           flow, so this costs ~11 probes per story instead of ~2000. Nothing is mutated
-           during the search, so the layout read stays cached. */
-        const lineBoundary = (story, lines, hiBound) => {
-            const s = state.get(story);
-            const lineHeight = parseFloat(getComputedStyle(story).lineHeight);
-            if (!lineHeight) return s.total;
-            const limitIndex = Math.min(hiBound === undefined ? s.total : hiBound, s.total);
-            let firstTop = null;
-            for (let i = 0; i < limitIndex && firstTop === null; i++) firstTop = rectTopAt(s, i);
-            if (firstTop === null) return limitIndex;
-            const limit = firstTop + lines * lineHeight - 1;
-            let lo = 0;
-            let hi = limitIndex;
-            while (lo < hi) {
-                const mid = (lo + hi) >> 1;
-                const top = rectTopAt(s, mid);
-                if (top === null || top <= limit) lo = mid + 1;
-                else hi = mid;
-            }
-            return lo;
-        };
+           This is deliberately NOT a measurement. An earlier version cut at a measured
+           3-line boundary, and every bug this feature shipped came from that: the boundary
+           had to be re-measured because `text-wrap: pretty` re-wraps what remains once you
+           cut it, re-measured again on `fonts.ready` because the pre-paint pass uses
+           fallback metrics, and re-measured AGAIN on resize because a cut in characters
+           goes stale the moment the box changes width. A block boundary is a DOM fact:
+           width-independent, font-independent, wrap-independent. It needs none of that.
 
+           No ellipsis: the teaser ends on a real full stop, so a trailing "…" would read as
+           a typo. The toggle is the affordance. */
         const truncate = (story) => {
             const s = state.get(story);
-            reveal(story, s.total); /* measure against the full text */
-            const full = s.nodes.map((n) => n.full).join('');
-            const backOff = (index) => {
-                const space = full.slice(0, index).lastIndexOf(' ');
-                return space > 0 ? space : index;
-            };
-
-            const boundary = lineBoundary(story, LINES, s.total);
-            if (boundary >= s.total) {
-                s.cut = s.total;
-                return;
-            }
-            s.cut = backOff(boundary);
-            reveal(story, s.cut, true);
-
-            /* global.css sets `p { text-wrap: pretty }`, which rebalances a paragraph's
-               line breaks across its WHOLE content. Line breaking is therefore not greedy:
-               cutting text changes how the text that remains wraps, so a boundary measured
-               against the full story can render one line too tall once applied. Measure
-               what was actually rendered and tighten until it fits. Converges in 1-2
-               passes; the bound stops it probing the emptied nodes past the cut. */
-            for (let pass = 0; pass < 4; pass++) {
-                const rendered = lineBoundary(story, LINES, s.cut);
-                if (rendered >= s.cut) break;
-                s.cut = backOff(rendered);
-                reveal(story, s.cut, true);
-            }
+            /* The first TOP-LEVEL child, not s.blocks[0] — s.blocks mixes nesting levels
+               (p, ul, ol, li), so a story opening with a list would pick the <ul> and then
+               its <li> separately. */
+            const first = story.children[0];
+            const inside = first ? s.nodes.filter((n) => first.contains(n.node)) : [];
+            const end = inside.length ? inside[inside.length - 1].end : 0;
+            s.cut = end > 0 && end < s.total ? end : s.total;
+            reveal(story, s.cut);
         };
 
         const finish = (story) => {
@@ -651,23 +648,8 @@ const education = (await getCollection('education')).sort(
         initStories();
         document.addEventListener('astro:after-swap', initStories);
 
-        /* The cut is measured against a specific box width, so it goes stale the moment the
-           box changes width — window snap, phone rotation, zoom, devtools. The old
-           `max-height: 77px` clamp was viewport-independent and could not fail this way;
-           `.collapsed` now carries no CSS at all, so nothing else catches it. Measured
-           without this: resizing 1600px -> 760px rendered collapsed cards at up to 6 lines
-           instead of 3. initStories is idempotent and only re-cuts collapsed stories, so an
-           expanded or mid-run card is left alone. */
-        let resizeTimer = 0;
-        window.addEventListener('resize', () => {
-            clearTimeout(resizeTimer);
-            resizeTimer = setTimeout(initStories, 150);
-        }, {passive: true});
-
-        /* The pre-paint pass measures with fallback font metrics, so the boundary is wrong
-           until the web fonts swap in. Re-truncate once they land. The page already
-           reflows on font swap, so this rides along invisibly. Only collapsed stories are
-           re-cut, so a story the reader already expanded is left alone. */
-        if (document.fonts && document.fonts.ready) document.fonts.ready.then(initStories);
+        /* No resize listener and no fonts.ready re-truncate: the teaser is a block boundary,
+           so it does not depend on box width or font metrics and cannot go stale. Both were
+           required only by the measured-cut approach this replaces. */
     }
 </script>

--- a/src/pages/about.astro
+++ b/src/pages/about.astro
@@ -55,8 +55,8 @@ const education = (await getCollection('education')).sort(
                         <ExperienceCard experience={exp}/>
                         {index === 0 && (
                             <div id='timelineFlashback' class='grid grid-cols-[28px_1fr] md:grid-cols-[48px_1fr]'>
-                                <div></div>
-                                <p class='kicker mb-7'>How I got here</p>
+                                <div aria-hidden='true'></div>
+                                <h3 class='kicker mb-7'>How I got here</h3>
                             </div>
                         )}
                     </Fragment>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -175,7 +175,7 @@ const RECOMMENDATIONS_URL = `${LINKEDIN_ACCOUNT}/details/recommendations/`;
     <!-- 6 · Recommendations -->
     <section class='border-t border-hairline'>
         <div class='shell py-[72px] reveal'>
-            <div class='flex items-end justify-between gap-4 mb-10'>
+            <div class='flex flex-col items-start gap-4 mb-10 md:flex-row md:items-end md:justify-between'>
                 <div>
                     <p class='kicker mb-4'>Kind words · LinkedIn recommendations</p>
                     <h2 class='font-display text-4xl md:text-[44px] font-semibold text-strong leading-tight'>

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -263,6 +263,10 @@
 
 	/* Dotted stack line — items separated by caramel middle dots, no chips */
 	.stack-line {
+		display: flex;
+		flex-wrap: wrap;
+		align-items: baseline;
+		column-gap: 7px;
 		font-size: 13px;
 		line-height: 2;
 		color: var(--text-muted);
@@ -274,12 +278,17 @@
 		letter-spacing: .12em;
 		text-transform: uppercase;
 		color: var(--accent);
-		margin-right: 10px;
+		margin-right: 3px;
 	}
 
-	.stack-line .stack-dot {
+	/* The dot rides at the START of each tag after the first, so it stays glued to its
+	   tag and can never wrap onto a new line alone the way a standalone flex item would.
+	   column-gap (7px) sits before the dot, margin-right (7px) after it — matching the old
+	   `margin: 0 7px` dot spacing exactly. */
+	.stack-line .stack-tag + .stack-tag::before {
+		content: '·';
 		color: var(--accent);
-		margin: 0 7px;
+		margin-right: 7px;
 	}
 
 	/* Badges */


### PR DESCRIPTION
The experience entries read as a story, but the timeline runs newest-first, so reading top-to-bottom meant reading the story backwards. The kicker also said `2019 → Today` while the list ran the other way.

Keeps newest-first as the default and makes the descent deliberate: start years descend down the rail, the kicker matches the order, a "How I got here" sub-header frames the history as a flashback, and each card carries a "Before that" cue.

Adds a `Latest first | Story order` toggle for readers who want the story in order. It persists in localStorage and flips direction text via a single CSS class, so no JavaScript rewrites strings.

Verified in a real browser at both widths: the traveling dot stays synced in both orders (zero drift), the leading card's cue is suppressed either way, and the stored order applies before first paint.

Design: `docs/superpowers/specs/2026-07-16-about-timeline-reading-direction-design.md`