### PR TITLE
Add the InZsh zsh theme project

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "joe-inz-personal-website",
   "type": "module",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "description": "A personal website built with Astro and Tailwind CSS.",
   "scripts": {
     "dev": "astro dev",

--- a/src/content/projects/inz-forge-ui.md
+++ b/src/content/projects/inz-forge-ui.md
@@ -2,7 +2,7 @@
 name: "Inz Forge UI"
 demoLink: "https://github.com/joeloudjinz/inz-forge-ui"
 isUnderConstruction: true
-isFeatured: true
+isFeatured: false
 version: "0.0.1"
 tags: [ "Portable Components", "Nx", "Typescript", "Angular", "VueJS", "Cypress", "Playwright" ]
 id: "inz-foge-ui-library"

--- a/src/content/projects/inzsh.md
+++ b/src/content/projects/inzsh.md
@@ -1,0 +1,15 @@
+---
+name: "InZsh"
+demoLink: "https://github.com/joeloudjinz/inzsh"
+isUnderConstruction: true
+isFeatured: true
+version: "0.1.0"
+tags: [ "Zsh", "Shell", "Oh My Zsh", "Powerline", "JoeInz Design System", "WCAG AA", "ShellSpec" ]
+id: "inzsh-zsh-theme"
+---
+
+A zsh prompt that carries prayer times in it, computed on your machine — no network, no
+dependencies beyond zsh. The rest is built from the JoeInz design system rather than a palette
+that happened to look nice: every colour is a semantic role with a verified contrast ratio in
+light and dark, checked under colour-blindness simulation, and no state is signalled by colour
+alone. Two presets ship with it, sharp and warm.

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -16,7 +16,7 @@ import {getExperiences, isCurrentRole, formatExperienceDate} from '../utils/expe
 // Newest first, current role on top
 const experiences = (await getExperiences()).reverse();
 const skills = (await getCollection('majorSkills')).sort((a, b) => a.data.order - b.data.order);
-const featuredProjects = (await getOrderedProjects()).filter((p) => p.data.isFeatured).slice(0, 2);
+const featuredProjects = (await getOrderedProjects()).filter((p) => p.data.isFeatured);
 const latestPosts = (await getSortedPosts()).slice(0, 4);
 const recommendations = (await getCollection('recommendations')).sort((a, b) => a.data.id - b.data.id);
 const interests = await getCollection('interests');
@@ -120,7 +120,7 @@ const RECOMMENDATIONS_URL = `${LINKEDIN_ACCOUNT}/details/recommendations/`;
                 </div>
                 <a href='/projects/' class='arrow-link text-[15px] shrink-0'>All projects <span class='arrow'>→</span></a>
             </div>
-            <div class='grid md:grid-cols-2 gap-6'>
+            <div class='grid md:grid-cols-3 gap-6'>
                 {featuredProjects.map((project) => (
                         <div class='cardx cardx-hover p-8'>
                             <div class='flex items-center gap-3 flex-wrap mb-4'>

--- a/src/utils/projects.ts
+++ b/src/utils/projects.ts
@@ -5,6 +5,7 @@ export type ProjectCollectionEntry = CollectionEntry<'projects'>;
 
 // Hand-curated display order (by frontmatter id)
 export const PROJECT_ORDER = [
+  'inzsh-zsh-theme',
   'inz-foge-ui-library',
   'dynamic-module-loader-dotnet',
   'data-seeder-dotnet',


### PR DESCRIPTION
Adds InZsh to the projects collection and gives it a featured card on the home page.

Inz Forge UI is no longer featured, so it drops off the home page but stays listed on /projects. InZsh is inserted at the top of `PROJECT_ORDER` so it leads the featured row.

Also fixes a mismatch the swap surfaced: three projects were flagged `isFeatured` but `.slice(0, 2)` only ever rendered two, so Data Seeder for .NET was silently dropped. The home grid is now three-up and shows every featured project.

Version bumped to 1.4.0.