### PR TITLE
Shorten the certificate poll budget to five minutes

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "joe-inz-personal-website",
   "type": "module",
-  "version": "1.5.0",
+  "version": "1.5.1",
   "description": "A personal website built with Astro and Tailwind CSS.",
   "scripts": {
     "dev": "astro dev",

--- a/scripts/subdomain/cli.mjs
+++ b/scripts/subdomain/cli.mjs
@@ -36,7 +36,7 @@ const USAGE = `
     --dry-run          Show what would run without doing it.
     --from=<phase>     Skip phases before this one.
     --until=<phase>    Stop after this one.
-    --wait=<minutes>   Cert-issuance poll budget (default 15).
+    --wait=<minutes>   Cert-issuance poll budget (default 5).
     --port=<n>         Local verification port (default 8788).
     --allow-worktree   Deploy from a linked worktree. Deploys belong in the main
                        checkout; this is the deliberate exception.
@@ -47,7 +47,11 @@ const USAGE = `
 function parseArgs(argv) {
   const positional = [];
   const flags = {
-    dryRun: false, waitMs: 15 * 60_000, port: 8788, from: null, until: null,
+    // Five minutes, not fifteen. Certificate issuance usually lands well inside
+    // it, and a timeout here is not a failure — the phase exits zero saying
+    // "re-run later" and resumes exactly where it stopped. A short budget that
+    // hands the terminal back is more useful than a long one that looks hung.
+    dryRun: false, waitMs: 5 * 60_000, port: 8788, from: null, until: null,
     allowWorktree: false
   };
 


### PR DESCRIPTION
Drops the default `--wait` from 15 minutes to 5.

A timeout on the cert-issuance phase is not a failure — it exits zero with "re-run later" and resumes where it stopped. A shorter budget hands the terminal back sooner instead of looking hung. `--wait=<minutes>` still overrides it.

Version 1.5.0 → 1.5.1 (patch).