### PR TITLE
Fix credential leak into local dev server, and pin its compatibility date

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "joe-inz-personal-website",
   "type": "module",
-  "version": "1.5.1",
+  "version": "1.5.2",
   "description": "A personal website built with Astro and Tailwind CSS.",
   "scripts": {
     "dev": "astro dev",

--- a/scripts/subdomain/lib/run.mjs
+++ b/scripts/subdomain/lib/run.mjs
@@ -27,10 +27,15 @@ export function run(command, args, { cwd, env, quiet = false } = {}) {
  * Starts a long-running process and returns a handle with a stop().
  * Used for the local Pages dev server during verification.
  */
+/**
+ * `env` REPLACES the process environment rather than extending it — the one
+ * caller needs to withhold credentials, and a merge would quietly hand them
+ * back. See envWithoutSecrets.
+ */
 export function background(command, args, { cwd, env } = {}) {
   const child = spawn(command, args, {
     cwd,
-    env: { ...process.env, ...env },
+    env: env ?? process.env,
     stdio: ['ignore', 'pipe', 'pipe'],
   });
 
@@ -61,12 +66,53 @@ export function background(command, args, { cwd, env } = {}) {
 }
 
 /**
- * Wrangler defaults compatibility_date to today, but the bundled workerd binary
- * only supports up to the previous day, so `pages dev` dies on startup with a
- * confusing "newest date supported by this server binary" error. Pin yesterday.
+ * Compatibility date for the local `pages dev` runtime.
+ *
+ * Wrangler defaults this to *today*, which the bundled workerd refuses because
+ * its ceiling is whatever the installed binary shipped with. The first version
+ * of this pinned "yesterday", which worked on the day it was written and broke
+ * the next: the ceiling does not advance with the calendar, it is fixed by the
+ * wrangler version. Wrangler 4.120.0 tops out at 2026-08-08, so "yesterday" was
+ * already a day too new the following morning.
+ *
+ * A fixed past date has no downside here. Compatibility dates gate opt-in
+ * behaviour changes in the Workers runtime, and this server has no Worker to
+ * change — wrangler prints "No Functions. Shimming..." and serves static assets
+ * with `_redirects`. Nothing this verifies depends on the date, so the only
+ * requirement is that every wrangler we might run accepts it.
  */
-export function yesterdayISO(now = new Date()) {
-  const d = new Date(now);
-  d.setUTCDate(d.getUTCDate() - 1);
-  return d.toISOString().slice(0, 10);
+export const LOCAL_COMPATIBILITY_DATE = '2025-01-01';
+
+/**
+ * Environment for the local dev server, with credentials withheld.
+ *
+ * Two separate leaks, and the second is the one that actually bit.
+ *
+ * 1. Process environment. Filtered by pattern below. Wrangler only forwards
+ *    these when CLOUDFLARE_INCLUDE_PROCESS_ENV is set, so this is hygiene
+ *    rather than a live fix — but it costs nothing and the server needs no
+ *    credentials at all.
+ *
+ * 2. `.env` on disk. Since August 2025 wrangler loads .env itself in local dev
+ *    and binds every key into the Worker, independent of what it is handed as
+ *    an environment. That is how CLOUDFLARE_API_TOKEN and
+ *    PORKBUN_SECRET_API_KEY ended up listed as bindings on a static-file server
+ *    that has no use for either — and, because this tool prints the server's
+ *    output when it fails to start, into the terminal too. Wrangler masks the
+ *    values; the names still leak, and the Worker still gets them.
+ *
+ *    CLOUDFLARE_LOAD_DEV_VARS_FROM_DOT_ENV=false is the documented off switch,
+ *    and is the fix. Filtering the process environment alone does nothing here.
+ *
+ * Deny by pattern rather than allow by name: an allowlist that forgets PATH or
+ * HOME fails confusingly, while catching one variable too many costs nothing.
+ */
+const SECRET_PATTERN = /(TOKEN|SECRET|_KEY|APIKEY|PASSWORD|CREDENTIAL|ACCOUNT_ID)/i;
+
+export function envWithoutSecrets(source = process.env) {
+  const clean = Object.fromEntries(
+    Object.entries(source).filter(([key]) => !SECRET_PATTERN.test(key))
+  );
+  clean.CLOUDFLARE_LOAD_DEV_VARS_FROM_DOT_ENV = 'false';
+  return clean;
 }

--- a/scripts/subdomain/phases.mjs
+++ b/scripts/subdomain/phases.mjs
@@ -7,7 +7,7 @@ import { readDomainStatus } from './lib/cloudflare.mjs';
 import { PendingError, TerminalError } from './lib/errors.mjs';
 import { buildRedirects, expectations } from './lib/redirects.mjs';
 import { assetPathsFrom, probeAll, waitForServer } from './lib/probe.mjs';
-import { background, run, yesterdayISO } from './lib/run.mjs';
+import { LOCAL_COMPATIBILITY_DATE, background, envWithoutSecrets, run } from './lib/run.mjs';
 
 const SETUP = 'setup';
 const DEPLOY = 'deploy';
@@ -380,9 +380,10 @@ export const phases = [
           String(flags.port),
           '--ip',
           '127.0.0.1',
-          `--compatibility-date=${yesterdayISO()}`,
+          `--compatibility-date=${LOCAL_COMPATIBILITY_DATE}`,
         ],
-        { cwd: paths.root }
+        // Credentials withheld: this server serves static files and needs none.
+        { cwd: paths.root, env: envWithoutSecrets() }
       );
 
       try {


### PR DESCRIPTION
Two bugs, both surfaced by the first real deploy.

## Credentials bound into the local dev server

Wrangler has loaded `.env` itself in local dev since August 2025 and binds every key into the Worker. On a static-file server with no Functions that meant `CLOUDFLARE_API_TOKEN` and `PORKBUN_SECRET_API_KEY` were listed as bindings — and because this tool prints the server's output when it fails to start, their names reached the terminal. Values were masked, the names were not, and the Worker received them regardless.

Fixed with `CLOUDFLARE_LOAD_DEV_VARS_FROM_DOT_ENV=false`, the documented off switch. Verified against a scratch fixture with a fake `.env`: all three secrets bound before, absent after.

Filtering the process environment is kept as hygiene but does not fix this on its own — wrangler reads the file directly.

## Compatibility date

The date was pinned to "yesterday", which worked the day it was written and broke the next morning. The ceiling is set by the installed wrangler version, not the calendar — 4.120.0 tops out at 2026-08-08. Now a fixed past date, which has no effect on a server with no Functions.

This is what blocked `verify-local` on the deploy attempt.

Version 1.5.1 → 1.5.2 (patch).