### PR TITLE
Point the InZsh card at its own subdomain

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "joe-inz-personal-website",
   "type": "module",
-  "version": "1.5.2",
+  "version": "1.5.3",
   "description": "A personal website built with Astro and Tailwind CSS.",
   "scripts": {
     "dev": "astro dev",

--- a/src/content/projects/inzsh.md
+++ b/src/content/projects/inzsh.md
@@ -1,13 +1,18 @@
 ---
 name: "InZsh"
 demoLink: "https://github.com/joeloudjinz/inzsh"
-# The showcase page. Site-relative on purpose: the page is destined for
-# inzsh.abdellahaddoun.com and says so in its canonical, but that host does not
-# exist yet — an absolute link to it would be a dead link on the live site from
-# the moment this ships. The page is built into this site's dist and deployed
-# with it, so /inzsh/ is a real, working page today and stays one after the
-# subdomain lands. Swap this one line for the absolute URL when it does.
-projectPageLink: "/inzsh/"
+# The showcase page, now at its own host. This was site-relative until the
+# subdomain existed; it is absolute because the page's canonical says
+# inzsh.abdellahaddoun.com, and a card pointing at /inzsh/ would send readers to
+# a copy that only tells search engines to look elsewhere.
+#
+# Absolute also earns the new tab: linkAttrs reads the scheme and opens off-site
+# links in a new window, so the "project pages open in a new tab" behaviour comes
+# from this one line rather than a flag someone has to remember.
+#
+# /inzsh/ still builds and still works. It is what the subdomain's own catch-all
+# redirects back to, so it has to keep existing — it just is not what we link.
+projectPageLink: "https://inzsh.abdellahaddoun.com/"
 isUnderConstruction: false
 isFeatured: true
 version: "1.0.0"

--- a/src/utils/projects.ts
+++ b/src/utils/projects.ts
@@ -7,14 +7,14 @@ export type ProjectCollectionEntry = CollectionEntry<'projects'>;
 // Hand-curated display order (by frontmatter id)
 export const PROJECT_ORDER = [
   'inzsh-zsh-theme',
-  'inz-foge-ui-library',
   'dynamic-module-loader-dotnet',
   'data-seeder-dotnet',
   'algerian-rib-validator',
+  'inz-foge-ui-library',
   'pipeline-pattern-dotnet',
+  'repository-pattern-laravel',
   'pipeline-pattern-typescript',
-  'onion-architecture-dotnet',
-  'repository-pattern-laravel'
+  'onion-architecture-dotnet'
 ];
 
 /**


### PR DESCRIPTION
The showcase page is live at `inzsh.abdellahaddoun.com`, so the card links there instead of `/inzsh/`.

Worth doing rather than cosmetic: the page's canonical already names the subdomain, so a card pointing at `/inzsh/` was sending readers to a copy whose only job is telling search engines to look elsewhere. It also means the subdomain finally has an inbound link — until now nothing on the site linked to it.

Absolute also earns the new tab for free. `linkAttrs` reads the scheme and opens off-site links in a new window, so the "project pages open in a new tab" behaviour comes from this one line rather than a flag.

`/inzsh/` still builds and must keep existing — it is what the subdomain's own catch-all redirects back to.

Verified in the built output: both the home page and `/projects` render `href="https://inzsh.abdellahaddoun.com/" target="_blank" rel="noopener noreferrer"`, no site-relative `/inzsh/` card links remain, and the sitemap still excludes the page.

Version 1.5.2 → 1.5.3 (patch).