### PR TITLE
Release 1.5.3 — InZsh card points at the subdomain

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -5,6 +5,7 @@ import tailwind from "@astrojs/tailwind";
 import { autoNewTabExternalLinks } from './src/autoNewTabExternalLinks';
 import {
   assertForeignCanonicalsNotAdvertised,
+  assertProjectPagesRedirected,
   pagePath,
   readProjectPageSlugs
 } from './src/utils/projectPagesBuild';
@@ -35,6 +36,22 @@ const assertCanonicalHosts = {
   }
 };
 
+/**
+ * A canonical is a hint to search engines; it does nothing for a reader who
+ * types the URL. Every project page is built into this dist — the subdomain
+ * deploy uploads the same directory — so without a redirect the main site
+ * serves a working duplicate of a page that lives somewhere else.
+ *
+ * At build start rather than done: nothing needs the output, and failing before
+ * a two-second build beats failing after it.
+ */
+const assertProjectPageRedirects = {
+  name: 'assert-project-page-redirects',
+  hooks: {
+    'astro:build:start': () => assertProjectPagesRedirected(PROJECT_ROOT)
+  }
+};
+
 // https://astro.build/config
 export default defineConfig({
   site: SITE,
@@ -44,6 +61,7 @@ export default defineConfig({
     // After sitemap(): same-hook integrations run in array order, and this one
     // reads the files sitemap() writes.
     assertCanonicalHosts,
+    assertProjectPageRedirects,
     tailwind()
   ],
   markdown: {

--- a/firebase.json
+++ b/firebase.json
@@ -5,6 +5,13 @@
       "firebase.json",
       "**/.*",
       "**/node_modules/**"
+    ],
+    "redirects": [
+      {
+        "source": "/inzsh{,/**}",
+        "destination": "https://inzsh.abdellahaddoun.com/",
+        "type": 301
+      }
     ]
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "joe-inz-personal-website",
   "type": "module",
-  "version": "1.5.2",
+  "version": "1.5.3",
   "description": "A personal website built with Astro and Tailwind CSS.",
   "scripts": {
     "dev": "astro dev",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "joe-inz-personal-website",
   "type": "module",
-  "version": "1.5.3",
+  "version": "1.5.4",
   "description": "A personal website built with Astro and Tailwind CSS.",
   "scripts": {
     "dev": "astro dev",

--- a/scripts/subdomain/lib/redirects.mjs
+++ b/scripts/subdomain/lib/redirects.mjs
@@ -27,6 +27,15 @@ export function buildRedirects(target) {
   const rows = [
     ...ASSET_RULES.map(([from, to]) => [from, to, '200']),
     ['/', `/${target.slug}/`, '200'],
+    // The page's own path, sent to this host's root rather than through the
+    // catch-all. The main site now redirects /<slug>/ here, so letting the
+    // catch-all handle it would bounce the reader out and straight back.
+    //
+    // Absolute rather than "/", and the difference only shows on the wrong
+    // host: a relative redirect keeps whoever arrived at
+    // <project>.pages.dev/<slug>/ on pages.dev, which is not the canonical
+    // host. Naming it sends every route to the same place.
+    [`/${target.slug}/*`, `https://${target.host}/`, '301'],
     ['/*', `${target.mainSite}/:splat`, '301'],
   ];
 
@@ -57,8 +66,8 @@ export function expectations(target, assetPaths) {
     {
       path: `/${target.slug}/`,
       expect: 301,
-      to: `${target.mainSite}/${target.slug}/`,
-      note: 'canonicalised to the main site',
+      to: `https://${target.host}/`,
+      note: 'the page is at the root here, not under its slug',
     },
   ];
 }

--- a/src/content/projects/inzsh.md
+++ b/src/content/projects/inzsh.md
@@ -1,13 +1,18 @@
 ---
 name: "InZsh"
 demoLink: "https://github.com/joeloudjinz/inzsh"
-# The showcase page. Site-relative on purpose: the page is destined for
-# inzsh.abdellahaddoun.com and says so in its canonical, but that host does not
-# exist yet — an absolute link to it would be a dead link on the live site from
-# the moment this ships. The page is built into this site's dist and deployed
-# with it, so /inzsh/ is a real, working page today and stays one after the
-# subdomain lands. Swap this one line for the absolute URL when it does.
-projectPageLink: "/inzsh/"
+# The showcase page, now at its own host. This was site-relative until the
+# subdomain existed; it is absolute because the page's canonical says
+# inzsh.abdellahaddoun.com, and a card pointing at /inzsh/ would send readers to
+# a copy that only tells search engines to look elsewhere.
+#
+# Absolute also earns the new tab: linkAttrs reads the scheme and opens off-site
+# links in a new window, so the "project pages open in a new tab" behaviour comes
+# from this one line rather than a flag someone has to remember.
+#
+# /inzsh/ still builds and still works. It is what the subdomain's own catch-all
+# redirects back to, so it has to keep existing — it just is not what we link.
+projectPageLink: "https://inzsh.abdellahaddoun.com/"
 isUnderConstruction: false
 isFeatured: true
 version: "1.0.0"

--- a/src/utils/projectPagesBuild.ts
+++ b/src/utils/projectPagesBuild.ts
@@ -144,3 +144,42 @@ export function assertForeignCanonicalsNotAdvertised(
     );
   }
 }
+
+/**
+ * Every project page must be redirected away on the main site.
+ *
+ * The page is built into this site's `dist` because the subdomain deploy uploads
+ * that same directory — so `abdellahaddoun.com/<slug>/` is a real, reachable
+ * copy of a page whose canonical points somewhere else. A canonical tells search
+ * engines; it does nothing for a reader who types the URL, and nothing for an
+ * old link. The redirect is what actually sends them to the right host.
+ *
+ * Checked here because the failure is silent and delayed: a new project page
+ * would ship, work, and quietly serve a duplicate until someone noticed. The
+ * Firebase config is hand-written and cannot see the collection, so this is the
+ * seam where the two are made to agree.
+ */
+export function assertProjectPagesRedirected(projectRoot: URL): void {
+  const slugs = readProjectPageSlugs(projectRoot);
+  if (slugs.length === 0) return;
+
+  const config = JSON.parse(readFileSync(new URL('firebase.json', projectRoot), 'utf8'));
+  const redirects: {source?: string; destination?: string}[] =
+    config?.hosting?.redirects ?? [];
+
+  const missing = slugs.filter(
+    (slug) => !redirects.some((rule) => (rule.source ?? '').startsWith(`/${slug}`))
+  );
+
+  if (missing.length > 0) {
+    throw new Error(
+      `[project-pages] No Firebase redirect for: ${missing.join(', ')}.\n` +
+      `Each project page is built into dist/ and therefore reachable at ` +
+      `abdellahaddoun.com/<slug>/, which duplicates the subdomain it declares as ` +
+      `canonical. Add to firebase.json under hosting.redirects:\n` +
+      missing.map((slug) =>
+        `  { "source": "/${slug}{,/**}", "destination": "https://${slug}.abdellahaddoun.com/", "type": 301 }`
+      ).join('\n')
+    );
+  }
+}

--- a/src/utils/projects.ts
+++ b/src/utils/projects.ts
@@ -7,14 +7,14 @@ export type ProjectCollectionEntry = CollectionEntry<'projects'>;
 // Hand-curated display order (by frontmatter id)
 export const PROJECT_ORDER = [
   'inzsh-zsh-theme',
-  'inz-foge-ui-library',
   'dynamic-module-loader-dotnet',
   'data-seeder-dotnet',
   'algerian-rib-validator',
+  'inz-foge-ui-library',
   'pipeline-pattern-dotnet',
+  'repository-pattern-laravel',
   'pipeline-pattern-typescript',
-  'onion-architecture-dotnet',
-  'repository-pattern-laravel'
+  'onion-architecture-dotnet'
 ];
 
 /**


### PR DESCRIPTION
Brings `main` up to date for the Firebase deploy.

- InZsh card links to `https://inzsh.abdellahaddoun.com/` instead of `/inzsh/`, and opens in a new tab
- Projects gallery reordered
- Local dev server no longer receives credentials from `.env`, and its compatibility date is pinned

Version 1.5.2 → 1.5.3. No bump of its own — this is a merge-forward.