### PR TITLE
Redirect the main site's copy of a project page to its subdomain

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -5,6 +5,7 @@ import tailwind from "@astrojs/tailwind";
 import { autoNewTabExternalLinks } from './src/autoNewTabExternalLinks';
 import {
   assertForeignCanonicalsNotAdvertised,
+  assertProjectPagesRedirected,
   pagePath,
   readProjectPageSlugs
 } from './src/utils/projectPagesBuild';
@@ -35,6 +36,22 @@ const assertCanonicalHosts = {
   }
 };
 
+/**
+ * A canonical is a hint to search engines; it does nothing for a reader who
+ * types the URL. Every project page is built into this dist — the subdomain
+ * deploy uploads the same directory — so without a redirect the main site
+ * serves a working duplicate of a page that lives somewhere else.
+ *
+ * At build start rather than done: nothing needs the output, and failing before
+ * a two-second build beats failing after it.
+ */
+const assertProjectPageRedirects = {
+  name: 'assert-project-page-redirects',
+  hooks: {
+    'astro:build:start': () => assertProjectPagesRedirected(PROJECT_ROOT)
+  }
+};
+
 // https://astro.build/config
 export default defineConfig({
   site: SITE,
@@ -44,6 +61,7 @@ export default defineConfig({
     // After sitemap(): same-hook integrations run in array order, and this one
     // reads the files sitemap() writes.
     assertCanonicalHosts,
+    assertProjectPageRedirects,
     tailwind()
   ],
   markdown: {

--- a/firebase.json
+++ b/firebase.json
@@ -5,6 +5,13 @@
       "firebase.json",
       "**/.*",
       "**/node_modules/**"
+    ],
+    "redirects": [
+      {
+        "source": "/inzsh{,/**}",
+        "destination": "https://inzsh.abdellahaddoun.com/",
+        "type": 301
+      }
     ]
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "joe-inz-personal-website",
   "type": "module",
-  "version": "1.5.3",
+  "version": "1.5.4",
   "description": "A personal website built with Astro and Tailwind CSS.",
   "scripts": {
     "dev": "astro dev",

--- a/scripts/subdomain/lib/redirects.mjs
+++ b/scripts/subdomain/lib/redirects.mjs
@@ -27,6 +27,15 @@ export function buildRedirects(target) {
   const rows = [
     ...ASSET_RULES.map(([from, to]) => [from, to, '200']),
     ['/', `/${target.slug}/`, '200'],
+    // The page's own path, sent to this host's root rather than through the
+    // catch-all. The main site now redirects /<slug>/ here, so letting the
+    // catch-all handle it would bounce the reader out and straight back.
+    //
+    // Absolute rather than "/", and the difference only shows on the wrong
+    // host: a relative redirect keeps whoever arrived at
+    // <project>.pages.dev/<slug>/ on pages.dev, which is not the canonical
+    // host. Naming it sends every route to the same place.
+    [`/${target.slug}/*`, `https://${target.host}/`, '301'],
     ['/*', `${target.mainSite}/:splat`, '301'],
   ];
 
@@ -57,8 +66,8 @@ export function expectations(target, assetPaths) {
     {
       path: `/${target.slug}/`,
       expect: 301,
-      to: `${target.mainSite}/${target.slug}/`,
-      note: 'canonicalised to the main site',
+      to: `https://${target.host}/`,
+      note: 'the page is at the root here, not under its slug',
     },
   ];
 }

--- a/src/utils/projectPagesBuild.ts
+++ b/src/utils/projectPagesBuild.ts
@@ -144,3 +144,42 @@ export function assertForeignCanonicalsNotAdvertised(
     );
   }
 }
+
+/**
+ * Every project page must be redirected away on the main site.
+ *
+ * The page is built into this site's `dist` because the subdomain deploy uploads
+ * that same directory — so `abdellahaddoun.com/<slug>/` is a real, reachable
+ * copy of a page whose canonical points somewhere else. A canonical tells search
+ * engines; it does nothing for a reader who types the URL, and nothing for an
+ * old link. The redirect is what actually sends them to the right host.
+ *
+ * Checked here because the failure is silent and delayed: a new project page
+ * would ship, work, and quietly serve a duplicate until someone noticed. The
+ * Firebase config is hand-written and cannot see the collection, so this is the
+ * seam where the two are made to agree.
+ */
+export function assertProjectPagesRedirected(projectRoot: URL): void {
+  const slugs = readProjectPageSlugs(projectRoot);
+  if (slugs.length === 0) return;
+
+  const config = JSON.parse(readFileSync(new URL('firebase.json', projectRoot), 'utf8'));
+  const redirects: {source?: string; destination?: string}[] =
+    config?.hosting?.redirects ?? [];
+
+  const missing = slugs.filter(
+    (slug) => !redirects.some((rule) => (rule.source ?? '').startsWith(`/${slug}`))
+  );
+
+  if (missing.length > 0) {
+    throw new Error(
+      `[project-pages] No Firebase redirect for: ${missing.join(', ')}.\n` +
+      `Each project page is built into dist/ and therefore reachable at ` +
+      `abdellahaddoun.com/<slug>/, which duplicates the subdomain it declares as ` +
+      `canonical. Add to firebase.json under hosting.redirects:\n` +
+      missing.map((slug) =>
+        `  { "source": "/${slug}{,/**}", "destination": "https://${slug}.abdellahaddoun.com/", "type": 301 }`
+      ).join('\n')
+    );
+  }
+}


### PR DESCRIPTION
Good catch before deploying. Every project page is built into this `dist` — the subdomain deploy uploads the same directory — so `abdellahaddoun.com/inzsh/` is a working duplicate of a page whose canonical points elsewhere. A canonical tells search engines; it does nothing for a reader who types the URL or follows an old link.

## Three parts

**Firebase redirect.** `/inzsh{,/**}` → `https://inzsh.abdellahaddoun.com/`, 301. Firebase ranks redirects above static content, so it fires even though `dist/inzsh/index.html` exists.

**A build guard, so future project pages can't be forgotten.** `firebase.json` is hand-written and cannot see the collection, so the build now fails when a project page has no matching redirect. This is the "and any future project webpage" half — the failure is otherwise silent and delayed. The error names the slug and prints the exact JSON to paste.

**The subdomain's own slug path.** `inzsh.abdellahaddoun.com/inzsh/` used to fall through to the main site, which now redirects straight back. It goes to the subdomain root instead. Absolute rather than relative, which only shows on the wrong host: a relative redirect would keep someone who arrived at `inzsh.pages.dev/inzsh/` on `pages.dev`.

## Verified

Against the **Firebase emulator**, not assumed: `/inzsh`, `/inzsh/` and `/inzsh/deep/path` all 301 to the subdomain, and the home page, projects page and a blog post are untouched. The `{,/**}` glob does cover the bare path, the trailing slash and subpaths.

The guard was tested by removing the redirect and confirming the build fails with the right message.

Subdomain rules verified against the real Pages runtime: 9 probes pass.

Version 1.5.3 → 1.5.4 (patch).