### PR TITLE
Compare where a redirect lands, not how the header is spelled

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "joe-inz-personal-website",
   "type": "module",
-  "version": "1.5.4",
+  "version": "1.5.5",
   "description": "A personal website built with Astro and Tailwind CSS.",
   "scripts": {
     "dev": "astro dev",

--- a/scripts/subdomain/lib/probe.mjs
+++ b/scripts/subdomain/lib/probe.mjs
@@ -31,12 +31,21 @@ async function probeOne(base, { path, expect, to }) {
 
   const location = response.headers.get('location');
   const statusOk = response.status === expect;
-  const targetOk = !to || location === to;
+
+  // Compare where the reader LANDS, not how the header is spelled. Cloudflare
+  // normalises Location by host: a redirect to the same host it was asked on
+  // comes back as "/", and the identical rule serving *.pages.dev comes back
+  // absolute. Both are correct and both send the reader to the same place, so
+  // a string compare fails a working redirect depending on which host asked —
+  // which is exactly what it did, passing locally against 127.0.0.1 and
+  // failing in production. Resolving is also what a browser does.
+  const landsAt = location ? new URL(location, `${base}${path}`).href : null;
+  const targetOk = !to || landsAt === new URL(to).href;
 
   return {
     path,
     ok: statusOk && targetOk,
-    actual: `${response.status}${location ? ` → ${location}` : ''}`,
+    actual: `${response.status}${landsAt ? ` → ${landsAt}` : ''}`,
   };
 }
 


### PR DESCRIPTION
The subdomain deploy succeeded and `verify-remote` reported it broken. The deploy was fine; the check was wrong.

Cloudflare normalises `Location` by host. Asked on `inzsh.abdellahaddoun.com`, a redirect to that same host comes back as `/`. The identical rule asked on `inzsh.pages.dev` comes back as `https://inzsh.abdellahaddoun.com/`. Both are correct and both land the reader in the same place.

The probe compared the raw header string, so it passed locally against `127.0.0.1` (different host, absolute header) and failed in production against the real host (same host, relative header). Same rule, same behaviour, opposite verdicts.

Now it resolves `Location` against the request URL before comparing — what a browser does — so it tests where you land rather than how the header is written.

Worth fixing rather than working around: a verification that fails on correct output is worse than none, because it trains you to re-run past it.

Verified both directions: 9 probes pass against the live subdomain, and 9 pass locally against the Pages runtime.

Version 1.5.4 → 1.5.5 (patch).