### PR TITLE
Align the site with the Joe Inz Design System v1.1.0

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -72,6 +72,17 @@ export default defineConfig({
     tailwind({ applyBaseStyles: false })
   ],
   markdown: {
+    // Shiki writes its theme into an inline style attribute on every fence,
+    // which beats any stylesheet rule — so the theme has to be set HERE, not
+    // in CSS. Dual themes emit custom properties for both modes and switch on
+    // the .theme-dark class the site already toggles.
+    shikiConfig: {
+      themes: {
+        light: 'github-light',
+        dark: 'github-dark'
+      },
+      defaultColor: false
+    },
     rehypePlugins: [[autoNewTabExternalLinks, {
       domain: 'localhost:4321'
     }]]

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "joe-inz-personal-website",
-  "version": "1.5.0",
+  "version": "1.7.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "joe-inz-personal-website",
-      "version": "1.5.0",
+      "version": "1.7.0",
       "license": "MIT",
       "dependencies": {
         "@astrojs/check": "^0.9.4",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "joe-inz-personal-website",
   "type": "module",
-  "version": "1.6.0",
+  "version": "1.7.0",
   "description": "A personal website built with Astro and Tailwind CSS.",
   "scripts": {
     "dev": "astro dev",

--- a/src/components/BandHeader.astro
+++ b/src/components/BandHeader.astro
@@ -32,7 +32,7 @@
 // The standfirst goes through CodeSpans: it is the one string of the four this
 // column draws that is a sentence rather than a label, and the steps band's
 // names a flag in it. The kicker and the heading do not, for the reason their
-// own treatments give: small caps at 11px and Fraunces at 44 are not registers
+// own treatments give: small caps at 11px and Literata at 44 are not registers
 // a monospace run belongs in. Nor does the link, whose label is the text of a
 // control and so chrome rather than copy.
 import ArrowLink from '@src/components/ArrowLink.astro';

--- a/src/components/Byline.astro
+++ b/src/components/Byline.astro
@@ -3,7 +3,7 @@ import {FULL_NAME} from '../consts';
 ---
 
 <div class='flex items-center gap-3'>
-    <span class='w-9 h-9 rounded-full bg-accent text-on-accent font-display font-semibold text-[13px] flex items-center justify-center shrink-0'
+    <span class='w-9 h-9 rounded-full bg-accent text-[color:var(--choc-ink)] font-display font-semibold text-[13px] flex items-center justify-center shrink-0'
           aria-hidden='true'>AA</span>
     <span class='text-sm font-medium text-body'>{FULL_NAME} <span class='text-muted'>· @joeinz</span></span>
 </div>

--- a/src/components/Byline.astro
+++ b/src/components/Byline.astro
@@ -5,5 +5,5 @@ import {FULL_NAME} from '../consts';
 <div class='flex items-center gap-3'>
     <span class='w-9 h-9 rounded-full bg-accent text-[color:var(--choc-ink)] font-display font-semibold text-[13px] flex items-center justify-center shrink-0'
           aria-hidden='true'>AA</span>
-    <span class='text-sm font-medium text-body'>{FULL_NAME} <span class='text-muted'>· @joeinz</span></span>
+    <span class='text-[15px] font-medium text-body'>{FULL_NAME} <span class='text-muted'>· @joeinz</span></span>
 </div>

--- a/src/components/CodeBlock.astro
+++ b/src/components/CodeBlock.astro
@@ -160,7 +160,7 @@ const isEmpty = rows.length === 0;
     .code-pre:focus-visible {
         outline-width: 2px;
         outline-style: solid;
-        outline-color: var(--caramel-bright);
+        outline-color: var(--focus-ring);
         outline-offset: 4px;
         border-radius: 6px;
     }
@@ -240,7 +240,7 @@ const isEmpty = rows.length === 0;
     .code-copy:focus-visible {
         outline-width: 2px;
         outline-style: solid;
-        outline-color: var(--caramel-bright);
+        outline-color: var(--focus-ring);
         outline-offset: 3px;
         border-radius: 6px;
     }

--- a/src/components/CodeBlock.astro
+++ b/src/components/CodeBlock.astro
@@ -131,6 +131,7 @@ const isEmpty = rows.length === 0;
         overflow-x: auto;
         white-space: normal;
         font-family: var(--font-mono);
+        font-feature-settings: var(--mono-features);
         font-size: 14.5px;
         line-height: 1.6;
         color: var(--cream);

--- a/src/components/CodeBlock.astro
+++ b/src/components/CodeBlock.astro
@@ -132,7 +132,7 @@ const isEmpty = rows.length === 0;
         white-space: normal;
         font-family: var(--font-mono);
         font-feature-settings: var(--mono-features);
-        font-size: 14.5px;
+        font-size: 15px;
         line-height: 1.6;
         color: var(--cream);
     }

--- a/src/components/CodeBlock.astro
+++ b/src/components/CodeBlock.astro
@@ -132,7 +132,7 @@ const isEmpty = rows.length === 0;
         white-space: normal;
         font-family: var(--font-mono);
         font-size: 14.5px;
-        line-height: 1.7;
+        line-height: 1.6;
         color: var(--cream);
     }
 

--- a/src/components/ContactBlock.astro
+++ b/src/components/ContactBlock.astro
@@ -25,7 +25,7 @@ const {variant = 'centered'} = Astro.props;
         <section class='shell py-[72px] reveal'>
             <div class='flex flex-col md:flex-row md:items-center justify-between gap-8'>
                 <div>
-                    <h2 class='font-display text-[34px] font-semibold text-strong mb-3'>
+                    <h2 class='font-display text-[31px] font-semibold text-strong mb-3'>
                         I'm <span class='marker-wash'>one</span> message away.
                     </h2>
                     <p class='text-base text-muted'>

--- a/src/components/DataTable.astro
+++ b/src/components/DataTable.astro
@@ -224,6 +224,14 @@ const sentence = (cell: string | string[]) => (Array.isArray(cell) ? cell.join('
         margin-right: 7px;
     }
 
+    /* Raw caramel on navy measures 4.43:1, which is sub-AA at this mono size.
+       The dark-surface caramel is 5.58:1. The token stays raw caramel on
+       purpose, exactly as the system keeps it, so the lift belongs here at the
+       point of use rather than in the token. */
+    :global(html.theme-dark) .dt-token + .dt-token::before {
+        color: var(--caramel-bright);
+    }
+
     .dt-sentence {
         font-size: 14px;
         line-height: 1.55;

--- a/src/components/DataTable.astro
+++ b/src/components/DataTable.astro
@@ -204,7 +204,7 @@ const sentence = (cell: string | string[]) => (Array.isArray(cell) ? cell.join('
     .dt-tokens {
         font-family: var(--font-mono);
         font-feature-settings: var(--mono-features);
-        font-size: 13.5px;
+        font-size: 13px;
     }
 
     /* A token is one unbroken identifier and the narrow layout has no column for

--- a/src/components/DataTable.astro
+++ b/src/components/DataTable.astro
@@ -203,6 +203,7 @@ const sentence = (cell: string | string[]) => (Array.isArray(cell) ? cell.join('
     .dt-mono,
     .dt-tokens {
         font-family: var(--font-mono);
+        font-feature-settings: var(--mono-features);
         font-size: 13.5px;
     }
 

--- a/src/components/EducationCard.astro
+++ b/src/components/EducationCard.astro
@@ -14,8 +14,8 @@ const {title, universityName, universityUrl, facultyName, facultyUrl, university
     <p class='text-[13px] text-accent font-semibold tabular-nums mb-3'>
         {formatExperienceDate(startDate)} → {formatExperienceDate(endDate)}
     </p>
-    <h3 class='font-display text-2xl font-semibold text-strong mb-3 leading-snug'>{title}</h3>
-    <p class='text-[14.5px] text-muted leading-relaxed mb-3'>
+    <h3 class='font-display text-[25px] font-semibold text-strong mb-3 leading-snug'>{title}</h3>
+    <p class='text-[15px] text-muted leading-relaxed mb-3'>
         {universityUrl
             ? <a href={universityUrl} target='_blank' class='text-info font-semibold'>{universityName}</a>
             : <span>{universityName}</span>}
@@ -25,5 +25,5 @@ const {title, universityName, universityUrl, facultyName, facultyUrl, university
             : <span>{facultyName}</span>}
         <span> · {universityLocation}</span>
     </p>
-    <p class='text-[14.5px] text-muted leading-relaxed'>{education.body}</p>
+    <p class='text-[15px] text-muted leading-relaxed'>{education.body}</p>
 </div>

--- a/src/components/ExperienceCard.astro
+++ b/src/components/ExperienceCard.astro
@@ -28,12 +28,12 @@ const startYear = startDate.slice(0, 4);
             <span class='cue-back'>Before that</span><span class='cue-forward'>Then</span>
         </p>
         <div class='flex items-center gap-3 flex-wrap mb-3'>
-            <h3 class='font-display text-[27px] font-semibold text-strong leading-tight'>{roleName}</h3>
+            <h3 class='font-display text-[25px] font-semibold text-strong leading-tight'>{roleName}</h3>
             {current && <span class='badge-accent'>Current</span>}
             <span class='badge-outline'>{workTypeLabel}</span>
         </div>
 
-        <p class='text-sm text-muted mb-6'>
+        <p class='text-[15px] text-muted mb-6'>
             {companyName && (companyUrl
                 ? <a href={companyUrl} target='_blank' class='text-info font-semibold'>{companyName}</a>
                 : <span class='text-info font-semibold'>{companyName}</span>)}
@@ -41,10 +41,10 @@ const startYear = startDate.slice(0, 4);
         </p>
 
         <div id={`story-${experience.id}`}
-             class:list={['story text-[15.5px] leading-[1.65] text-body', !current && 'collapsed']}>
+             class:list={['story text-[15px] leading-[1.65] text-body', !current && 'collapsed']}>
             <Content/>
         </div>
-        <button class='story-toggle text-sm font-semibold text-info mt-4'
+        <button class='story-toggle text-[15px] font-semibold text-info mt-4'
                 aria-expanded={current ? 'true' : 'false'}
                 aria-controls={`story-${experience.id}`}>
             {current ? 'Show less ↑' : 'Read the story ↓'}

--- a/src/components/FaqDisclosure.astro
+++ b/src/components/FaqDisclosure.astro
@@ -95,7 +95,7 @@ const CLOSE_LABEL = 'Hide ↑';
 
     .faq-question {
         font-family: var(--font-display);
-        font-size: 21px;
+        font-size: 20px;
         font-weight: 600;
         line-height: 1.3;
         color: var(--text-strong);
@@ -104,7 +104,7 @@ const CLOSE_LABEL = 'Hide ↑';
     .faq-toggle {
         margin-left: auto;
         flex: none;
-        font-size: 14px;
+        font-size: 15px;
         font-weight: 600;
         color: var(--info);
         white-space: nowrap;
@@ -136,7 +136,7 @@ const CLOSE_LABEL = 'Hide ↑';
     .faq-answer {
         max-width: 680px;
         padding-top: 16px;
-        font-size: 15.5px;
+        font-size: 15px;
         line-height: 1.65;
         color: var(--text-body);
     }

--- a/src/components/FaqDisclosure.astro
+++ b/src/components/FaqDisclosure.astro
@@ -88,7 +88,7 @@ const CLOSE_LABEL = 'Hide ↑';
     .faq-summary:focus-visible {
         outline-width: 2px;
         outline-style: solid;
-        outline-color: var(--accent);
+        outline-color: var(--focus-ring);
         outline-offset: 4px;
         border-radius: 4px;
     }

--- a/src/components/PostsByYear.astro
+++ b/src/components/PostsByYear.astro
@@ -38,8 +38,8 @@ const shortDate = (date: Date) =>
                 {posts.map((post) => (
                         <a href={`/${post.id}/`}
                            class='flex flex-col sm:flex-row sm:items-center gap-2 sm:gap-6 py-6 border-b border-hairline last:border-b-0 group'>
-                            <span class='text-sm text-muted tabular-nums w-[100px] shrink-0'>{shortDate(post.data.pubDate)}</span>
-                            <span class='font-display text-xl md:text-[26px] font-semibold text-strong leading-snug grow group-hover:text-accent transition-colors duration-200'>
+                            <span class='text-[15px] text-muted tabular-nums w-[100px] shrink-0'>{shortDate(post.data.pubDate)}</span>
+                            <span class='font-display text-xl md:text-[25px] font-semibold text-strong leading-snug grow group-hover:text-accent transition-colors duration-200'>
                                 {post.data.title}
                             </span>
                             <span class='flex gap-2 flex-wrap shrink-0'>

--- a/src/components/ProjectItem.astro
+++ b/src/components/ProjectItem.astro
@@ -33,7 +33,7 @@ const {target: pageTarget, rel: pageRel} = linkAttrs(projectPageLink ?? '');
 
 <article class='cardx cardx-hover p-8'>
     <div class='flex items-center gap-3 flex-wrap mb-4'>
-        <h2 class='font-display text-[26px] font-semibold text-strong leading-tight'>
+        <h2 class='font-display text-[25px] font-semibold text-strong leading-tight'>
             <a href={leadHref} target={leadTarget} rel={leadRel}>{name}</a>
         </h2>
         {isUnderConstruction && <span class='badge-accent badge-pulse'>In progress</span>}
@@ -55,19 +55,19 @@ const {target: pageTarget, rel: pageRel} = linkAttrs(projectPageLink ?? '');
                 repeated where the title goes. It leads because a project that
                 has a page of its own is asking to be read there first. */}
             {projectPageLink && (
-                    <a href={projectPageLink} target={pageTarget} rel={pageRel} class='arrow-link text-sm'>
+                    <a href={projectPageLink} target={pageTarget} rel={pageRel} class='arrow-link text-[15px]'>
                         View the project page <span class='arrow'>→</span>
                     </a>
             )}
             {/* Conditional for the same reason the block above is: a project
                 with no public repository has no repository to link. */}
             {demoLink && (
-                    <a href={demoLink} target='_blank' rel={demoLinkRel} class='arrow-link text-sm'>
+                    <a href={demoLink} target='_blank' rel={demoLinkRel} class='arrow-link text-[15px]'>
                         View repository <span class='arrow'>→</span>
                     </a>
             )}
             {publishedPackageLink && (
-                    <a href={publishedPackageLink} target='_blank' class='arrow-link text-sm'>
+                    <a href={publishedPackageLink} target='_blank' class='arrow-link text-[15px]'>
                         View package on NuGet <span class='arrow'>→</span>
                     </a>
             )}

--- a/src/components/Prose.astro
+++ b/src/components/Prose.astro
@@ -6,7 +6,7 @@
 </div>
 
 <style is:global>
-	/* Article typography: 720px measure, Inter body + Fraunces display */
+	/* Article typography: 720px measure, Readex Pro body + Literata display */
 	.article {
 		font-size: 18px;
 		line-height: 1.7;
@@ -87,7 +87,7 @@
 		margin: .5em 0;
 	}
 
-	/* Blockquote: caramel rule above, Fraunces italic, indented, no border-left box */
+	/* Blockquote: caramel rule above, Literata italic, indented, no border-left box */
 	.article blockquote {
 		margin: 2em 0 2em 36px;
 		padding: 0;

--- a/src/components/Prose.astro
+++ b/src/components/Prose.astro
@@ -28,13 +28,13 @@
 	}
 
 	.article h2 {
-		font-size: 34px;
+		font-size: 31px;
 		line-height: 1.2;
 		margin: 1.6em 0 .6em;
 	}
 
 	.article h3 {
-		font-size: 27px;
+		font-size: 25px;
 		line-height: 1.25;
 		margin: 1.4em 0 .5em;
 	}
@@ -105,7 +105,7 @@
 
 	.article blockquote p {
 		font-family: var(--font-display);
-		font-size: 22px;
+		font-size: 20px;
 		font-style: italic;
 		line-height: 1.5;
 		color: var(--text-body);

--- a/src/components/Prose.astro
+++ b/src/components/Prose.astro
@@ -120,10 +120,23 @@
 	.article code {
 		font-family: var(--font-mono);
 		font-size: .85em;
-		background: var(--surface-soft);
+		background: var(--cream-deep);
 		border: 1px solid var(--hairline);
 		border-radius: 6px;
 		padding: 2px 6px;
+	}
+
+	html.theme-dark .article code {
+		background: var(--navy-deep);
+	}
+
+	/* Block code stays transparent on its fence in dark mode too. Without this
+	   the rule above wins on specificity — two classes beat one — and paints an
+	   opaque box behind the fence's own background. It is currently the same
+	   colour, so it hides, but the two are set independently and need not stay
+	   equal. */
+	html.theme-dark .article pre code {
+		background: none;
 	}
 
 	.article pre {

--- a/src/components/Prose.astro
+++ b/src/components/Prose.astro
@@ -119,6 +119,7 @@
 	   and block cases are one declaration — `.article pre code` inherits it. */
 	.article code {
 		font-family: var(--font-mono);
+		font-feature-settings: var(--mono-features);
 		font-size: .85em;
 		background: var(--cream-deep);
 		border: 1px solid var(--hairline);

--- a/src/components/ScrollTop.astro
+++ b/src/components/ScrollTop.astro
@@ -51,7 +51,7 @@ const LABEL = 'Scroll to top';
         background: var(--surface-card);
         box-shadow: var(--shadow-card);
         color: var(--text-strong);
-        font-size: 17px;
+        font-size: 16px;
         line-height: 1;
         cursor: pointer;
         /* Opacity and nothing else: no travel, no scale, no bounce.

--- a/src/components/ScrollTop.astro
+++ b/src/components/ScrollTop.astro
@@ -94,7 +94,7 @@ const LABEL = 'Scroll to top';
     .scroll-top:focus-visible {
         outline-width: 2px;
         outline-style: solid;
-        outline-color: var(--accent);
+        outline-color: var(--focus-ring);
         outline-offset: 3px;
     }
 

--- a/src/components/SkillCard.astro
+++ b/src/components/SkillCard.astro
@@ -9,10 +9,10 @@ const { skill } = Astro.props;
 ---
 
 <div class="cardx cardx-hover p-8 break-inside-avoid mb-6">
-  <h3 class="font-display text-[22px] font-semibold text-strong mb-3">
+  <h3 class="font-display text-[20px] font-semibold text-strong mb-3">
     {skill.data.title}
   </h3>
-  <p class="text-[14.5px] leading-relaxed text-muted">
+  <p class="text-[15px] leading-relaxed text-muted">
     {skill.body}
   </p>
 </div>

--- a/src/components/ToolboxMarquee.astro
+++ b/src/components/ToolboxMarquee.astro
@@ -54,7 +54,7 @@ const ariaLabel = `Technologies: ${tiles.map((t) => t.loved ? `${t.label} (favor
                         'w-auto max-w-[74px] object-contain',
                         tile.loved ? 'h-[38px]' : 'h-[34px]'
                     ]} loading='lazy'/>
-                    <span class='text-xs text-muted'>{tile.label}</span>
+                    <span class='text-[13px] text-muted'>{tile.label}</span>
                 </div>
         ))}
     </div>

--- a/src/components/projectpage/BandPage.astro
+++ b/src/components/projectpage/BandPage.astro
@@ -265,27 +265,27 @@ const canonical = `https://${page.data.subdomain}/`;
                     wash draws a block over the text between them — and a phrase
                     that cannot wrap is as wide as its font-size makes it. At the
                     72px the design asks for, held at every width, "knows the
-                    hour" measures 499px set in Fraunces and 581px in the Georgia
+                    hour" measures 528px set in Literata and 581px in the Georgia
                     fallback — the wider of the two, and so the one that binds —
                     against the 272px content box a 320px screen leaves inside
-                    the shell. That is 227px and 309px past the content edge, far
+                    the shell. That is 256px and 309px past the content edge, far
                     enough to scroll the document rather than merely spill into
                     the gutter. Stepping the size at breakpoints leaves the
                     widths between them untested; scaling with the viewport
                     reaches 72px by 848px, where the design's two-column widths
                     begin, and holds every width below it.
 
-                    The floor is 30px rather than the 34px Fraunces alone would
-                    allow, because Fraunces is not what draws the first paint.
+                    The floor is 30px rather than the 34px Literata alone would
+                    allow, because Literata is not what draws the first paint.
                     It loads with display=swap, so the phrase is set in Georgia —
-                    the next family in the stack — until the webfont lands, and
-                    Georgia is the wider face. Measured at 320px, where the shell
-                    leaves a 272px content box: the span is 263px in Fraunces at
-                    34px and 285px in Georgia, so 34px spent the whole swap
-                    window 13px into the 24px gutter. Nothing scrolled — the
+                    the next Latin family in the stack — until the webfont lands,
+                    and Georgia is the wider face. Measured at 320px, where the
+                    shell leaves a 272px content box: the span is 255px in
+                    Literata at 34px and 285px in Georgia, so 34px spent the whole
+                    swap window 13px into the 24px gutter. Nothing scrolled — the
                     document stayed 320 wide — which is exactly why the clamp,
                     not the scrollbar, has to be the thing that catches it. At
-                    30px Georgia measures 254px, leaving 18px, and Fraunces 232px.
+                    30px Georgia measures 254px, leaving 18px, and Literata 225px.
                     Georgia is the case that sets the floor: the rest of the
                     stack — Times New Roman, then the generic serif — sets the
                     same phrase at 238px where Georgia needs 285px.
@@ -691,7 +691,7 @@ const canonical = `https://${page.data.subdomain}/`;
                 same 30px floor for the same reason — the washed phrase cannot
                 wrap, so its width follows the font-size, and the size has to
                 hold in the Georgia fallback display=swap paints first rather
-                than only in Fraunces.
+                than only in Literata.
 
                 Sharing the floor is what lets the two headings share one bound
                 on their wash: 250px at 30px in Georgia, checked in the schema.

--- a/src/components/projectpage/PinboardPage.astro
+++ b/src/components/projectpage/PinboardPage.astro
@@ -44,18 +44,20 @@ const meterPercent = (ratio: number) => Math.max(0, Math.min(100, ((ratio - 1) /
 <BaseLayout title={seo.title} description={seo.description ?? mirror.en.body} gradient='warm'
             keywords={seo.keywords?.join(', ')} imageAlt={seo.imageAlt}
             canonical={canonical} chrome='subdomain' projectName={projectName}>
-    {/* Page-only faces. A <link> in the body is valid HTML and keeps the fonts
-        off every other page. The site's Fraunces/Inter still load via BaseHead
-        for the shared chrome.
+    {/* Page-only faces: the Arabic pair, and only them. A <link> in the body is
+        valid HTML and keeps these two off every other page. The Latin three —
+        Literata, Readex Pro and JetBrains Mono — now come from the site's own
+        head, so asking for them again here would request the same families
+        twice.
 
-        All five of the system's faces. An earlier cut of this page left Amiri
-        out because nothing spoke in it, with a note that it would join the day
-        a pin needed it — the expanded pins are that day: the faces row renders
-        its specimen and the nameplate's law cards set the name in it. Only 400
-        and 700 are requested because Amiri ships nothing else, and the
-        system's own law forbids synthesising the weights a face lacks. */}
+        An earlier cut of this page left Amiri out because nothing spoke in it,
+        with a note that it would join the day a pin needed it — the expanded
+        pins are that day: the faces row renders its specimen and the
+        nameplate's law cards set the name in it. Only 400 and 700 are
+        requested because Amiri ships nothing else, and the system's own law
+        forbids synthesising the weights a face lacks. */}
     <link rel='stylesheet'
-          href='https://fonts.googleapis.com/css2?family=Literata:ital,opsz,wght@0,7..72,400;0,7..72,600;0,7..72,700;1,7..72,500&family=Readex+Pro:wght@400;500;600;700&family=Harmattan:wght@400;700&family=Amiri:wght@400;700&family=JetBrains+Mono:wght@400;500&display=swap'/>
+          href='https://fonts.googleapis.com/css2?family=Harmattan:wght@400;700&family=Amiri:wght@400;700&display=swap'/>
 
     {/* Without a script this page has no reveal to wait for. global.css starts
         .reveal at opacity 0 and only the observer in BaseLayout adds
@@ -1669,8 +1671,9 @@ const meterPercent = (ratio: number) => Math.max(0, Math.min(100, ((ratio - 1) /
            three of the page's accent fills take that same pair — this button,
            the light switch and the mirror's flip — so the fork is one decision
            applied consistently, not a button that disagrees with its
-           neighbours. The site-wide pair is deliberately left alone for now and
-           is the planned site-adjustment pass's to reconcile. */
+           neighbours. The site now sets the same pair site-wide, for the same
+           reason and at the same measured ratio, so this is no longer a fork
+           from it. */
         .dsp-btn-pri { background: var(--accent); border: 1.5px solid var(--accent); color: var(--choc-ink); }
         /* Both buttons hover into the same inversion: the page's ink becomes
            the ground and the page's ground becomes the ink, which is one rule

--- a/src/components/widgets/PublisherCard.astro
+++ b/src/components/widgets/PublisherCard.astro
@@ -47,6 +47,6 @@ const {pubDate, readingTime} = Astro.props;
                 <Image src={LinkedinCream} width={18} height={18} alt='' class='hidden dark:block'/>
             </a>
         </span>
-        <a href={LINKEDIN_ACCOUNT} target='_blank' class='arrow-link text-sm'>Follow <span class='arrow'>→</span></a>
+        <a href={LINKEDIN_ACCOUNT} target='_blank' class='arrow-link text-[15px]'>Follow <span class='arrow'>→</span></a>
     </div>
 </div>

--- a/src/components/widgets/TableOfContent.astro
+++ b/src/components/widgets/TableOfContent.astro
@@ -16,7 +16,7 @@ const toc = headings.filter((heading) => heading.depth === 2);
 			{toc.map((heading) => (
 				<li>
 					<a href={'#' + heading.slug}
-					   class='toc-link block text-sm text-muted rounded-[9px] px-3 py-2 transition-colors duration-200 hover:text-strong'>
+					   class='toc-link block text-[15px] text-muted rounded-[9px] px-3 py-2 transition-colors duration-200 hover:text-strong'>
 						{heading.text}
 					</a>
 				</li>

--- a/src/layouts/components/BaseHead.astro
+++ b/src/layouts/components/BaseHead.astro
@@ -127,10 +127,14 @@ const structuredData = software
 <link rel='icon' href='/favicon.png' type='image/png'/>
 <meta name='generator' content={Astro.generator}/>
 
-<!-- Webfonts: Fraunces (display) + Inter (UI/body) -->
+<!-- Webfonts: Literata (display) + Readex Pro (UI/body) + JetBrains Mono (code).
+     The foundation's five-face set; Fraunces and Inter are retired. Harmattan
+     and Amiri are the set's Arabic members and are NOT requested here: this site
+     has no Arabic content, and the Latin faces carry no Arabic glyphs, so the
+     stack simply never reaches them. -->
 <link rel='preconnect' href='https://fonts.googleapis.com'/>
 <link rel='preconnect' href='https://fonts.gstatic.com' crossorigin/>
-<link rel='stylesheet' href='https://fonts.googleapis.com/css2?family=Fraunces:ital,opsz,wght@0,9..144,400;0,9..144,500;0,9..144,600;1,9..144,500&family=Inter:wght@400;500;600;700&display=swap'/>
+<link rel='stylesheet' href='https://fonts.googleapis.com/css2?family=Literata:ital,opsz,wght@0,7..72,400;0,7..72,500;0,7..72,600;1,7..72,400&family=Readex+Pro:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap'/>
 
 <!-- SEO Meta Tags -->
 <meta name='robots' content='index, follow'/>

--- a/src/layouts/components/BaseHead.astro
+++ b/src/layouts/components/BaseHead.astro
@@ -127,11 +127,15 @@ const structuredData = software
 <link rel='icon' href='/favicon.png' type='image/png'/>
 <meta name='generator' content={Astro.generator}/>
 
-<!-- Webfonts: Literata (display) + Readex Pro (UI/body) + JetBrains Mono (code).
+{/* Webfonts: Literata (display) + Readex Pro (UI/body) + JetBrains Mono (code).
      The foundation's five-face set; Fraunces and Inter are retired. Harmattan
      and Amiri are the set's Arabic members and are NOT requested here: this site
      has no Arabic content, and the Latin faces carry no Arabic glyphs, so the
-     stack simply never reaches them. -->
+     stack simply never reaches them.
+
+     An Astro comment and not an HTML one: an HTML comment in a component's
+     template is emitted verbatim into every page, so this note used to ship to
+     the browser site-wide and kept the retired names alive in the output. */}
 <link rel='preconnect' href='https://fonts.googleapis.com'/>
 <link rel='preconnect' href='https://fonts.gstatic.com' crossorigin/>
 <link rel='stylesheet' href='https://fonts.googleapis.com/css2?family=Literata:ital,opsz,wght@0,7..72,400;0,7..72,500;0,7..72,600;1,7..72,400&family=Readex+Pro:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap'/>

--- a/src/layouts/components/Footer.astro
+++ b/src/layouts/components/Footer.astro
@@ -48,7 +48,7 @@ const year = new Date().getFullYear();
                 leaves the box tree and its children stay direct flex items. */}
             <div class={isSubdomain ? 'flex flex-col sm:flex-row items-center gap-6' : 'contents'}>
                 {isSubdomain && (
-                        <a href={siteHref} class='arrow-link text-[14px]'>
+                        <a href={siteHref} class='arrow-link text-[15px]'>
                             {siteHost} <span class='arrow'>→</span>
                         </a>
                 )}

--- a/src/layouts/components/Header.astro
+++ b/src/layouts/components/Header.astro
@@ -384,6 +384,10 @@ const menuBreakpoint = hasSections ? 'xl:hidden' : 'md:hidden';
         :global(html:not(.theme-dark)) .toggle-seg-light,
         :global(html.theme-dark) .toggle-seg-dark {
             background: var(--accent);
+            /* This sets currentColor for a 15px SVG icon, not text, so the
+               non-text 3:1 threshold (WCAG 1.4.11) applies rather than 4.5:1.
+               3.07:1 clears that, so this keeps --on-accent while the text
+               consumers moved to the small-text ink. */
             color: var(--on-accent);
         }
 

--- a/src/layouts/components/Header.astro
+++ b/src/layouts/components/Header.astro
@@ -145,7 +145,7 @@ const menuBreakpoint = hasSections ? 'xl:hidden' : 'md:hidden';
                         on both sides and centres it between the two clusters,
                         which is where the main site's nav sits. Two auto margins
                         fighting over the same space would put it neither place. */}
-                    <span class:list={['font-display text-[18px] md:text-[22px] font-semibold text-strong truncate',
+                    <span class:list={['font-display text-[18px] md:text-[20px] font-semibold text-strong truncate',
                                        hasSections ? 'mr-auto xl:mr-0' : 'mr-auto']}>
                         {projectName}
                     </span>
@@ -287,7 +287,7 @@ const menuBreakpoint = hasSections ? 'xl:hidden' : 'md:hidden';
 
         <div class='flex items-center gap-4'>
             {isSubdomain && (
-                    <a href={siteHref} class='arrow-link shrink-0 text-[14px]'>
+                    <a href={siteHref} class='arrow-link shrink-0 text-[15px]'>
                         <span class='arrow-back'>‹</span>
                         <span class='md:hidden'>home</span>
                         <span class='hidden md:inline'>{siteHost}</span>
@@ -338,14 +338,14 @@ const menuBreakpoint = hasSections ? 'xl:hidden' : 'md:hidden';
                     {isSubdomain
                         ? sections.map((section) => (
                                 <a href={section.href} data-section-link
-                                   class='section-link py-3 text-[17px] border-b border-hairline last:border-b-0 text-body font-medium'>
+                                   class='section-link py-3 text-[16px] border-b border-hairline last:border-b-0 text-body font-medium'>
                                     {section.label}
                                 </a>
                         ))
                         : menu.map((item) => (
                                 <a href={item.link}
                                    class:list={[
-                                       'py-3 text-[17px] border-b border-hairline last:border-b-0',
+                                       'py-3 text-[16px] border-b border-hairline last:border-b-0',
                                        isActive(item.link)
                                            ? 'text-accent font-semibold'
                                            : 'text-body font-medium'
@@ -363,7 +363,7 @@ const menuBreakpoint = hasSections ? 'xl:hidden' : 'md:hidden';
             display: inline-flex;
             align-items: center;
             gap: 6px;
-            font-size: 10px;
+            font-size: 11px;
             font-weight: 600;
             text-transform: uppercase;
             letter-spacing: .08em;

--- a/src/layouts/components/Header.astro
+++ b/src/layouts/components/Header.astro
@@ -40,10 +40,15 @@ const hasSections = isSubdomain && sections.length > 0;
 // 279.9px. The short label is load-bearing, not a nicety.
 //
 // That leaves the name ~130px at 375px, and the schema allows 12 characters.
-// At Fraunces 22 a 12-character name wants ~147px and truncates, so the name
-// drops to 18px below md, where 12 characters need ~121px and fit. Only
-// pathological all-cap-W/M strings still overflow (~183px), which no product
-// name is. At md the padding doubles to 48px and 22px is comfortable again.
+// The widths that decided the 22px/18px split were measured against Fraunces,
+// which this site has since retired for Literata: at Fraunces 22 a 12-character
+// name wanted ~147px and truncated, so the name drops to 18px below md, where
+// 12 characters wanted ~121px and fit, and only pathological all-cap-W/M
+// strings still overflowed (~183px), which no product name is. Those three
+// figures have NOT been re-measured against Literata and should not be read as
+// its widths; the size split they justify still ships and wants re-checking in
+// the new face. At md the padding doubles to 48px and 22px is comfortable
+// again.
 //
 // WHERE THE SECTION ROW FOLDS, which is xl and not the md the main site's own
 // nav appears at. Measured on the built page, in the nav's content box:
@@ -79,8 +84,11 @@ const hasSections = isSubdomain && sections.length > 0;
 // borrows back from the gutter — with the name whole and nothing to spare.
 //
 // What that does NOT buy is room for a LONG name, and nothing on this line can.
-// At 375 the name has 106px, which is about ten characters of Fraunces 18
-// against the twelve the schema allows. It ellipsises rather than overflowing,
+// At 375 the name has 106px against the twelve characters the schema allows.
+// The 106px is a layout fact and holds whatever the name is set in; the old
+// note converted it to about ten characters of Fraunces 18, and that conversion
+// has not been redone for Literata, so treat the count as unbacked until it is.
+// Either way the room is short of twelve. It ellipsises rather than overflowing,
 // and the page's own title says the name in full one tap away, so this is the
 // price of a project asking for a section nav rather than a defect to design
 // around.

--- a/src/pages/404.astro
+++ b/src/pages/404.astro
@@ -12,7 +12,7 @@ import NotFoundImage from '@src/assets/img/404-not-found.png';
         <h1 class='font-display text-4xl md:text-[56px] font-semibold text-strong leading-tight my-6'>
             This page went <span class='marker-wash'>missing</span>.
         </h1>
-        <p class='text-[21px] text-muted mb-9'>
+        <p class='text-[20px] text-muted mb-9'>
             The page you're looking for is either moved or no longer exists.
         </p>
         <a href='/' class='btn btn-primary btn-lg'>Back home</a>

--- a/src/pages/[...slug].astro
+++ b/src/pages/[...slug].astro
@@ -60,7 +60,7 @@ const displayDate = (date: Date) =>
             transition:name={`post-title-${post.id}`}>
             {title}
         </h1>
-        <p class='text-[21px] text-muted leading-relaxed mb-7'>{description}</p>
+        <p class='text-[20px] text-muted leading-relaxed mb-7'>{description}</p>
         {(tags ?? []).length > 0 && (
                 <div class='flex justify-center flex-wrap gap-2'>
                     {(tags ?? []).map((tag) => <span class='chip'>{tag}</span>)}

--- a/src/pages/about.astro
+++ b/src/pages/about.astro
@@ -27,7 +27,7 @@ const education = (await getCollection('education')).sort(
             <h1 class='font-display text-4xl md:text-[56px] font-semibold text-strong tracking-[-0.015em] leading-tight mb-6'>
                 The <span class='marker-wash'>person</span> behind <span class='marker-wash whitespace-nowrap'>the commits</span>.
             </h1>
-            <p class='text-[21px] text-muted leading-relaxed max-w-[760px] mb-10'>
+            <p class='text-[20px] text-muted leading-relaxed max-w-[760px] mb-10'>
                 At my core, I'm a problem-solver. I thrive on untangling complex challenges by leading projects and
                 building software with the resources at hand. For me, technology isn't just about code; it's about
                 crafting smart, effective solutions that make a real difference.

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -43,7 +43,7 @@ const RECOMMENDATIONS_URL = `${LINKEDIN_ACCOUNT}/details/recommendations/`;
                 <h1 class='font-display text-5xl md:text-7xl font-semibold text-strong tracking-[-0.015em] leading-[1.1] mb-7'>
                     Make it <span class='marker-wash'>work</span>, then <span class='marker-wash whitespace-nowrap'>make it last</span>.
                 </h1>
-                <p class='text-[21px] text-muted leading-relaxed max-w-[560px] mb-9'>
+                <p class='text-[20px] text-muted leading-relaxed max-w-[560px] mb-9'>
                     At my core, I'm a problem-solver. I untangle complex challenges by leading teams and building
                     software with the resources at hand. I write about what I learn along the way.
                 </p>
@@ -89,7 +89,7 @@ const RECOMMENDATIONS_URL = `${LINKEDIN_ACCOUNT}/details/recommendations/`;
                                 isCurrentRole(exp) ? 'bg-accent' : 'border border-accent'
                             ]}></span>
                             <span class='text-base font-semibold text-strong grow'>{exp.data.roleName}</span>
-                            <span class='text-sm text-muted text-right hidden md:block'>
+                            <span class='text-[15px] text-muted text-right hidden md:block'>
                                 {[exp.data.companyName, exp.data.location].filter(Boolean).join(' · ')}
                             </span>
                         </div>
@@ -127,7 +127,7 @@ const RECOMMENDATIONS_URL = `${LINKEDIN_ACCOUNT}/details/recommendations/`;
                 {featuredProjects.map((project) => (
                         <div class='cardx cardx-hover p-8'>
                             <div class='flex items-center gap-3 flex-wrap mb-4'>
-                                <h3 class='font-display text-[26px] font-semibold text-strong'>
+                                <h3 class='font-display text-[25px] font-semibold text-strong'>
                                     {/* Showcase page when the project has one,
                                         repository otherwise — the same decision
                                         the gallery card makes, made in one
@@ -173,7 +173,7 @@ const RECOMMENDATIONS_URL = `${LINKEDIN_ACCOUNT}/details/recommendations/`;
                             <span class='text-[13px] text-muted tabular-nums w-[100px] shrink-0'>
                                 {post.data.pubDate.toLocaleDateString('en-us', {month: 'short', day: '2-digit', year: 'numeric', timeZone: 'UTC'})}
                             </span>
-                            <span class='font-display text-[21px] font-semibold text-strong leading-snug group-hover:text-accent transition-colors duration-200'>
+                            <span class='font-display text-[20px] font-semibold text-strong leading-snug group-hover:text-accent transition-colors duration-200'>
                                 {post.data.title}
                             </span>
                         </a>
@@ -199,10 +199,10 @@ const RECOMMENDATIONS_URL = `${LINKEDIN_ACCOUNT}/details/recommendations/`;
             <div class='grid md:grid-cols-2 gap-6'>
                 {recommendations.map((rec) => (
                         <div class='cardx p-8'>
-                            <blockquote class='font-display text-[19px] italic text-body leading-relaxed mb-5'>
+                            <blockquote class='font-display text-[20px] italic text-body leading-relaxed mb-5'>
                                 “{rec.data.pullQuote ?? pullQuote(rec.body)}”
                             </blockquote>
-                            <p class='text-[13.5px] text-muted'>
+                            <p class='text-[13px] text-muted'>
                                 {rec.data.name} · {rec.data.title} · {rec.data.relationship}
                             </p>
                         </div>
@@ -234,8 +234,8 @@ const RECOMMENDATIONS_URL = `${LINKEDIN_ACCOUNT}/details/recommendations/`;
             <div class='grid sm:grid-cols-3 gap-6'>
                 {interests.map((interest) => (
                         <div class='cardx cardx-hover p-8'>
-                            <h3 class='font-display text-[21px] font-semibold text-strong mb-3'>{interest.data.title}</h3>
-                            <p class='text-sm text-muted leading-relaxed'>{interest.data.description}</p>
+                            <h3 class='font-display text-[20px] font-semibold text-strong mb-3'>{interest.data.title}</h3>
+                            <p class='text-[15px] text-muted leading-relaxed'>{interest.data.description}</p>
                         </div>
                 ))}
             </div>

--- a/src/pages/posts/index.astro
+++ b/src/pages/posts/index.astro
@@ -15,7 +15,7 @@ const description = 'Find a set of articles, guides, tutorials, or posts about d
         <h1 class='font-display text-4xl md:text-[56px] font-semibold text-strong tracking-[-0.015em] leading-tight mb-6'>
             Writing.
         </h1>
-        <p class='text-[21px] text-muted leading-relaxed max-w-[760px]'>
+        <p class='text-[20px] text-muted leading-relaxed max-w-[760px]'>
             Articles, guides, tutorials, or simple posts about different fields and concepts in software engineering.
         </p>
     </section>

--- a/src/pages/projects/index.astro
+++ b/src/pages/projects/index.astro
@@ -24,7 +24,7 @@ const masonryColumns = [
         <h1 class='font-display text-4xl md:text-[56px] font-semibold text-strong tracking-[-0.015em] leading-tight mb-6'>
             Projects gallery.
         </h1>
-        <p class='text-[21px] text-muted leading-relaxed max-w-[760px]'>
+        <p class='text-[20px] text-muted leading-relaxed max-w-[760px]'>
             Open source projects I worked on or contributed to over time. Feel free to check them out. If you have
             any feedback, I'm happy to hear it.
         </p>
@@ -44,7 +44,7 @@ const masonryColumns = [
                     </div>
             ))}
         </div>
-        <p class='text-center font-display text-[21px] italic text-muted mt-14'>
+        <p class='text-center font-display text-[20px] italic text-muted mt-14'>
             More projects are yet to come, inchallah.
         </p>
     </section>

--- a/src/pages/tags/index.astro
+++ b/src/pages/tags/index.astro
@@ -57,15 +57,15 @@ const description = 'Post tags: concise keywords categorizing content for easy n
 		<h1 class='font-display text-4xl md:text-[56px] font-semibold text-strong tracking-[-0.015em] leading-tight mb-6'>
 			All tags.
 		</h1>
-		<p class='text-[21px] text-muted leading-relaxed max-w-[760px]'>{description}</p>
+		<p class='text-[20px] text-muted leading-relaxed max-w-[760px]'>{description}</p>
 	</section>
 	<section class='shell pb-[72px]'>
 		{groupedTags.map(({ letter, tags }) => (
 			<div class='flex gap-6 border-t border-hairline py-6 reveal'>
-				<h2 class='font-display text-[27px] font-semibold text-accent w-8 shrink-0 leading-none'>{letter}</h2>
+				<h2 class='font-display text-[25px] font-semibold text-accent w-8 shrink-0 leading-none'>{letter}</h2>
 				<div class='flex gap-2.5 flex-wrap items-center'>
 					{tags.map((tag: Tag) => (
-						<a class='chip !text-sm !px-3 !py-1.5 no-underline' href={`/tags/${tag.value}/`}>
+						<a class='chip !text-[15px] !px-3 !py-1.5 no-underline' href={`/tags/${tag.value}/`}>
 							{tag.label} <span class='text-accent'>({tag.postCount})</span>
 						</a>
 					))}

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -399,7 +399,12 @@
 
 	.btn-primary {
 		background: var(--accent);
-		color: var(--on-accent);
+		/* choc-ink, not --on-accent: the system's contrast card measures cream on
+		   caramel at 3.07 (AA-LARGE, marked legacy) and publishes choc-ink at
+		   4.59 as the small-text alternative. A 15px semibold label is small
+		   text. --accent does not flip between modes, so one value serves both.
+		   --on-accent is not wrong, it is simply for larger or bolder text. */
+		color: var(--choc-ink);
 	}
 
 	.btn-secondary {
@@ -480,7 +485,8 @@
 		font-weight: 600;
 		letter-spacing: .08em;
 		text-transform: uppercase;
-		color: var(--on-accent);
+		/* 11px is small text, so it takes the small-text ink, not --on-accent. */
+		color: var(--choc-ink);
 		background: var(--accent);
 		border-radius: 999px;
 		padding: 4px 12px;

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -250,6 +250,17 @@
 		background: var(--accent-wash);
 	}
 
+	/* Code keeps its own selection tint, per the developer layer. */
+	pre::selection, pre ::selection,
+	code::selection, code ::selection {
+		background: #E3D3AE;
+	}
+
+	html.theme-dark pre::selection, html.theme-dark pre ::selection,
+	html.theme-dark code::selection, html.theme-dark code ::selection {
+		background: #443A2B;
+	}
+
 	pre,
 	code {
 		font-size: 0.875rem;
@@ -616,15 +627,28 @@
 
    Both modes are gated on the html class so the two rules carry equal
    specificity. Prose.astro sets a fence background globally at (0,1,1); an
-   ungated selector here would be (0,1,0) and lose to it in light mode only. */
+   ungated selector here would be (0,1,0) and lose to it in light mode only.
+
+   The background is set separately below, on the fence only — Shiki's own
+   --shiki-*-bg is not used for it. */
 html:not(.theme-dark) .astro-code,
 html:not(.theme-dark) .astro-code span {
 	color: var(--shiki-light);
-	background-color: var(--shiki-light-bg);
 }
 
 html.theme-dark .astro-code,
 html.theme-dark .astro-code span {
 	color: var(--shiki-dark);
-	background-color: var(--shiki-dark-bg);
+}
+
+/* The fence sits on the system's own code background rather than the one baked
+   into the syntax theme, which is plain white and reads as a hole punched in
+   the page. Only the fence itself, never the token spans: they carry no
+   background of their own and must not gain one. */
+html:not(.theme-dark) .astro-code {
+	background-color: var(--cream-deep);
+}
+
+html.theme-dark .astro-code {
+	background-color: var(--navy-deep);
 }

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -335,13 +335,13 @@
 		color: var(--accent);
 	}
 
-	/* The value half of a labelled row: 15.5px on a 1.65 leading, in body ink.
+	/* The value half of a labelled row: 15px on a 1.65 leading, in body ink.
 	   Here rather than scoped inside DefinitionRows for the reason .micro-label
 	   is here — a second place draws it. A project page's configuration band ends
 	   in a note that is a row's value in everything but its label, and it had a
 	   byte-identical copy of these three declarations written inline. */
 	.def-value {
-		font-size: 15.5px;
+		font-size: 15px;
 		line-height: 1.65;
 		color: var(--text-body);
 	}
@@ -445,7 +445,7 @@
 	/* Tag chip */
 	.chip {
 		display: inline-block;
-		font-size: 12px;
+		font-size: 13px;
 		font-weight: 500;
 		padding: 4px 10px;
 		border-radius: 9px;

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -96,6 +96,12 @@
 	--dur-base: 220ms;
 	--dur-slow: 420ms;
 
+	/* Feedback durations, deliberately separate from --dur-* so the
+	   reduced-motion block can zero choreography without killing them.
+	   The foundation's law: choreography goes, feedback stays. */
+	--dur-feedback: 220ms;
+	--dur-feedback-fast: 120ms;
+
 	/* Gradients */
 	--grad-dark-subtle: linear-gradient(176deg, #212a48, #161c30 55%, #141a2c);
 	--grad-dark-glow: radial-gradient(135% 105% at 12% 8%, #2b3560, #1a2038 44%, #12172a);
@@ -388,8 +394,8 @@
 		font-size: 15px;
 		font-weight: 600;
 		padding: 12px 24px;
-		transition: filter var(--dur-base) var(--ease-standard),
-			background-color var(--dur-base) var(--ease-standard),
+		transition: filter var(--dur-feedback) var(--ease-standard),
+			background-color var(--dur-feedback) var(--ease-standard),
 			transform var(--dur-fast) var(--ease-standard);
 		cursor: pointer;
 	}
@@ -429,7 +435,7 @@
 		border: 1px solid var(--hairline);
 		background: var(--surface-soft);
 		color: var(--text-muted);
-		transition: filter var(--dur-base) var(--ease-standard);
+		transition: filter var(--dur-feedback) var(--ease-standard);
 	}
 
 	.chip:hover { filter: brightness(.95); }
@@ -440,7 +446,7 @@
 		border: 1px solid var(--hairline);
 		border-radius: 14px;
 		box-shadow: var(--shadow-soft);
-		transition: box-shadow var(--dur-base) var(--ease-standard), filter var(--dur-base) var(--ease-standard);
+		transition: box-shadow var(--dur-feedback) var(--ease-standard), filter var(--dur-feedback) var(--ease-standard);
 	}
 
 	.cardx-hover:hover {
@@ -508,7 +514,7 @@
 	.badge-pulse { animation: badge-pulse 3s var(--ease-standard) infinite; }
 
 	/* Arrow links: nudge the arrow on hover */
-	.arrow-link { color: var(--info); font-weight: 600; transition: color var(--dur-base) var(--ease-standard); }
+	.arrow-link { color: var(--info); font-weight: 600; transition: color var(--dur-feedback) var(--ease-standard); }
 	.arrow-link .arrow { display: inline-block; transition: transform var(--dur-base) var(--ease-standard); }
 	.arrow-link:hover { color: var(--accent); }
 	.arrow-link:hover .arrow { transform: translateX(2px); }
@@ -584,10 +590,16 @@
 	.reveal { opacity: 1; transform: none; }
 	.reveal.is-visible { transition: none; }
 
+	/* Choreography goes, feedback stays — the foundation's motion law.
+	   Restricting transition-property is what does the work: a transform-bearing
+	   transition simply stops being a transition, while colour, background and
+	   the brightness effect keep their normal duration. Hover, focus and
+	   selection must not go dead: 120-220ms of colour change is not vestibular,
+	   and removing it makes the interface feel broken rather than calm. */
 	*,
 	*::before,
 	*::after {
-		transition-duration: 1ms !important;
+		transition-property: color, background-color, border-color, filter, box-shadow, opacity !important;
 		animation-duration: 1ms !important;
 	}
 }

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -603,3 +603,28 @@
 		animation-duration: 1ms !important;
 	}
 }
+
+/* Shiki dual-theme. It emits --shiki-light and --shiki-dark on every token and
+   --shiki-light-bg / --shiki-dark-bg on the fence, and this picks which pair
+   applies.
+
+   Deliberately OUTSIDE @layer components. Shiki generates its class inside the
+   markdown pipeline at build time, so it never appears in the source Tailwind
+   scans, and a rule for it placed in a layer is purged from the bundle. The
+   dark rule would survive that purge on its own, because its selector names the
+   theme class, which leaves light mode silently unstyled.
+
+   Both modes are gated on the html class so the two rules carry equal
+   specificity. Prose.astro sets a fence background globally at (0,1,1); an
+   ungated selector here would be (0,1,0) and lose to it in light mode only. */
+html:not(.theme-dark) .astro-code,
+html:not(.theme-dark) .astro-code span {
+	color: var(--shiki-light);
+	background-color: var(--shiki-light-bg);
+}
+
+html.theme-dark .astro-code,
+html.theme-dark .astro-code span {
+	color: var(--shiki-dark);
+	background-color: var(--shiki-dark-bg);
+}

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -304,7 +304,7 @@
 		.shell { padding-inline: 96px; }
 	}
 
-	/* The site's micro-label treatment: 11px Inter, semibold, small caps. Four
+	/* The site's micro-label treatment: 11px Readex Pro, semibold, small caps. Four
 	   places had grown a byte-identical copy of it — a reference table's column
 	   headings, that table's stacked per-cell labels, a definition row's label,
 	   and the kicker. Declared once for both names rather than as a base class

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -118,13 +118,17 @@
 
 	--grain-svg: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='120' height='120'%3E%3Cfilter id='n'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.85' numOctaves='2' stitchTiles='stitch'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23n)'/%3E%3C/svg%3E");
 
-	/* Type */
-	--font-display: 'Fraunces', Georgia, 'Times New Roman', serif;
-	--font-sans: 'Inter', system-ui, -apple-system, 'Segoe UI', sans-serif;
-	/* Monospace is a stack, not a webfont: nothing here is downloaded, so a
-	   terminal capture and a config identifier cost no extra bytes. Shared so the
-	   code block and the reference tables cannot drift onto different mono faces. */
-	--font-mono: ui-monospace, 'SF Mono', 'Cascadia Mono', Menlo, Consolas, monospace;
+	/* Type — the foundation's role stacks, adopted verbatim. Harmattan sits in
+	   the display stack as its Arabic member; it is never downloaded here and
+	   never resolves, because the Latin faces carry no Arabic glyphs and this
+	   site has no Arabic content. Removing it would change a published stack. */
+	--font-display: 'Literata', 'Harmattan', Georgia, 'Times New Roman', serif;
+	--font-sans: 'Readex Pro', system-ui, -apple-system, 'Segoe UI', sans-serif;
+	/* Shared so the code block and the reference tables cannot drift onto
+	   different mono faces. */
+	--font-mono: 'JetBrains Mono', ui-monospace, 'SF Mono', Menlo, Consolas, monospace;
+	/* Ligatures off by default, per the foundation: != stays two glyphs. */
+	--mono-features: 'calt' 0, 'liga' 0;
 
 	/* The sticky header's own height. Measured off the built page rather than
 	   assumed: 18px of nav padding either side of the logo, plus the 1px
@@ -264,6 +268,7 @@
 	pre,
 	code {
 		font-size: 0.875rem;
+		font-feature-settings: var(--mono-features);
 	}
 }
 
@@ -362,6 +367,7 @@
 	   CodeBlock and DataTable read, and .theme-dark redefines the first. */
 	.code-token {
 		font-family: var(--font-mono);
+		font-feature-settings: var(--mono-features);
 		font-size: .92em;
 		color: var(--text-strong);
 		/* An identifier is one unbroken word with no break opportunity in it, and

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -27,6 +27,23 @@
 	--hair-light: #E4D8BE;
 	--hair-dark: #333C58;
 
+	/* State ramps — the six-state system, per tokens/colors.css */
+	--sage-deep: #4F6B4C;
+	--sage-wash: #E8E2C9;      --sage-wash-dark: #2B3440;
+	--sage-edge: #748A6D;      --sage-edge-dark: #6E8572;
+	--ink-blue-wash: #E5DECB;  --ink-blue-wash-dark: #2C334A;
+	--ink-blue-edge: #7D8497;  --ink-blue-edge-dark: #747EA3;
+	--madder: #7A443A;         --madder-bright: #E0A5AF;
+	--madder-wash: #E9DDC6;    --madder-wash-dark: #343144;
+	--madder-edge: #A27C6D;    --madder-edge-dark: #997683;
+	--ochre: #7A6119;          --ochre-bright: #E4CA83;
+	--ochre-wash: #ECE2C7;     --ochre-wash-dark: #31333C;
+	--ochre-edge: #988246;     --ochre-edge-dark: #8A7E60;
+	--putty-wash: #E7DEC6;     --putty-line: #908171;
+	--putty-text: #9B8D7B;     --putty-fill: #E6DCC5;   --putty-hair: #B9AC99;
+	--slate-wash: #2F3341;     --slate-line: #827F78;
+	--slate-text: #586281;     --slate-fill: #252B42;   --slate-hair: #414965;
+
 	/* Semantic aliases — light mode (default) */
 	--surface: var(--cream);
 	--surface-soft: var(--cream-soft);
@@ -38,6 +55,33 @@
 	--accent-wash: var(--highlight-wash);
 	--positive: var(--sage);
 	--info: var(--ink-blue);
+	--positive-text: var(--sage-deep);
+	--on-positive: var(--cream-bright);
+	--positive-wash: var(--sage-wash);
+	--positive-edge: var(--sage-edge);
+	--info-text: var(--ink-blue);
+	--on-info: var(--cream-bright);
+	--info-wash: var(--ink-blue-wash);
+	--info-edge: var(--ink-blue-edge);
+	--negative: var(--madder);
+	--negative-text: var(--madder);
+	--on-negative: var(--cream-bright);
+	--negative-wash: var(--madder-wash);
+	--negative-edge: var(--madder-edge);
+	--caution: var(--ochre);
+	--caution-text: var(--ochre);
+	--on-caution: var(--cream-bright);
+	--caution-wash: var(--ochre-wash);
+	--caution-edge: var(--ochre-edge);
+	--neutral: var(--choc-soft);
+	--neutral-text: var(--choc-soft);
+	--on-neutral: var(--cream-bright);
+	--neutral-wash: var(--putty-wash);
+	--neutral-edge: var(--putty-line);
+	--inactive-fill: var(--putty-fill);
+	--inactive-text: var(--putty-text);
+	--inactive-edge: var(--putty-hair);
+	--focus-ring: var(--ink-blue);
 	--hairline: var(--hair-light);
 	--on-accent: var(--cream);
 
@@ -116,6 +160,33 @@
 	--accent-wash: var(--highlight-wash-dark);
 	--positive: var(--sage-bright);
 	--info: var(--ink-blue-bright);
+	--positive-text: var(--sage-bright);
+	--on-positive: var(--navy-deep);
+	--positive-wash: var(--sage-wash-dark);
+	--positive-edge: var(--sage-edge-dark);
+	--info-text: var(--ink-blue-bright);
+	--on-info: var(--navy-deep);
+	--info-wash: var(--ink-blue-wash-dark);
+	--info-edge: var(--ink-blue-edge-dark);
+	--negative: var(--madder-bright);
+	--negative-text: var(--madder-bright);
+	--on-negative: var(--navy-deep);
+	--negative-wash: var(--madder-wash-dark);
+	--negative-edge: var(--madder-edge-dark);
+	--caution: var(--ochre-bright);
+	--caution-text: var(--ochre-bright);
+	--on-caution: var(--navy-deep);
+	--caution-wash: var(--ochre-wash-dark);
+	--caution-edge: var(--ochre-edge-dark);
+	--neutral: var(--cream-muted);
+	--neutral-text: var(--cream-muted);
+	--on-neutral: var(--navy-deep);
+	--neutral-wash: var(--slate-wash);
+	--neutral-edge: var(--slate-line);
+	--inactive-fill: var(--slate-fill);
+	--inactive-text: var(--slate-text);
+	--inactive-edge: var(--slate-hair);
+	--focus-ring: var(--ink-blue-bright);
 	--hairline: var(--hair-dark);
 	--on-accent: var(--choc);
 	--page-grad-glow: var(--grad-dark-glow);
@@ -123,6 +194,24 @@
 	--page-grad-warm: var(--grad-dark-warm);
 	--grain-opacity: .06;
 	color-scheme: dark;
+}
+
+/* Low-vision preference. Published by the foundation: the most-read quiet roles
+   must not be the ones that ignore the setting. Values are the system's own. */
+@media (prefers-contrast: more) {
+	:root {
+		--text-muted: #55463A;
+		--neutral-text: #55463A;
+		--inactive-text: #847668;
+		--hairline: #908171;
+	}
+
+	.theme-dark {
+		--text-muted: #D9D0B8;
+		--neutral-text: #D9D0B8;
+		--inactive-text: #8C96B8;
+		--hairline: #747EA3;
+	}
 }
 
 @layer base {

--- a/src/utils/bandStyles.ts
+++ b/src/utils/bandStyles.ts
@@ -9,7 +9,7 @@
  */
 
 /**
- * A band's own H2: Fraunces 44, one step down before there is room for it.
+ * A band's own H2: Literata 44, one step down before there is room for it.
  *
  * Two files draw it. The five split bands go through BandHeader; the full-width
  * ones — the deep dive, the gallery, the assurance cards, and the configuration

--- a/src/utils/navFit.ts
+++ b/src/utils/navFit.ts
@@ -14,42 +14,54 @@
  *
  * A character count cannot express the bound, for the reason src/utils/washFit.ts
  * gives at length about the washed headings: width follows case, not length.
- * "Prayer times" (12 characters) is 91px and "Verification" (12) is 96px, while
- * "FAQ" (3) is 29px and "Why" (3) is 33px. So the schema caps each label at 14
+ * "Prayer times" (12 characters) is 94px and "Verification" (12) is 86px, while
+ * "FAQ" (3) is 30px and "Why" (3) is 33px. So the schema caps each label at 14
  * characters to stop a heading being pasted into a nav item, and the row is added
  * up here in pixels.
  */
 
 /**
- * Advance width, in px, of one character at the binding condition: Inter, 600
- * weight, 15px.
+ * Advance width, in px, of one character at the binding condition: Readex Pro,
+ * 600 weight, 15px.
  *
  * 600 rather than the 500 the links are set in, because the current section's
  * link is drawn semibold and any of them can be the current one — so the widest
- * state the row ever reaches is every label at 600. Inter rather than a fallback
- * face: unlike the hero's wash, this row is chrome that wraps nothing and moves
- * nothing while the webfont swaps, and the system stack it swaps from is narrower
- * at these sizes than Inter is.
+ * state the row ever reaches is every label at 600. The webfont rather than a
+ * fallback face: unlike the hero's wash, this row is chrome that wraps nothing
+ * and moves nothing while the webfont swaps.
  *
- * Measured in Chrome the way washFit.ts measures its own table — a 20-character
- * run of each glyph, divided — then raised to the next half pixel, so summing
- * them can only over-state a row and never under-state it. Checked against the
- * rendered widths of eleven candidate labels: the sum is 1.4% to 10% generous,
- * the 10% being "FAQ", where the face kerns the F against the A. Kerning only
- * ever narrows, so the direction of the error is the safe one.
+ * Measured 2026-08-15 in Chromium, the way washFit.ts arrives at its own numbers
+ * — a 20-character run of each glyph in a span sized to its own text and with
+ * kerning off, divided by 20 — then raised to the next half pixel, so summing
+ * them can only over-state a row and never under-state it. The check
+ * `document.fonts.check("600 15px 'Readex Pro'")` answered true before a width
+ * was read, so these are the webfont's own advances and not a fallback's.
+ *
+ * Checked against eleven candidate labels: the sum runs from 2.0% generous at
+ * the tightest, "Why", to 6.6% at the loosest, "FAQ", and is never short of what
+ * the browser draws. Kerning only ever narrows, so the direction of the error is
+ * the safe one.
  */
 const ADVANCE_GROUPS: ReadonlyArray<readonly [string, number]> = [
-  [' ijl', 4], ['I', 4.5], ['.,:·!\'', 5], ['tf', 5.5], ['()/', 6],
-  ['r1', 6.5], ['-', 7], ['?sLzxk', 8.5], ['aJcvFye7', 9],
-  ['Eonhu52bdpqg', 9.5], ['3698PSRZB0T&4', 10], ['+K', 10.5], ['YXDU', 11],
-  ['CAVHGN', 11.5], ['OQ', 12], ['w', 13], ['mM', 14], ['W', 16]
+  ['.:\'·', 4], [',!l', 4.5], [' ij', 5], ['ft()', 6], ['-', 6.5],
+  ['r', 7], ['s', 7.5], ['zI?', 8], ['ac127', 8.5], ['evx+/35689', 9],
+  ['hknouyFLST', 9.5], ['bdgpqEJP04', 10], ['ABCYZ', 10.5], ['RVX', 11],
+  ['DKU&', 11.5], ['GH', 12], ['NOQw', 12.5], ['M', 13.5], ['m', 14.5],
+  ['W', 15]
 ];
 
 const ADVANCE = new Map<string, number>(
   ADVANCE_GROUPS.flatMap(([chars, px]) => [...chars].map((c) => [c, px] as const))
 );
 
-/** The widest glyph in the face, and what an unmeasured character is charged. */
+/**
+ * What an unmeasured character is charged.
+ *
+ * Wider than every glyph in the measured set — W, the widest, is 15 — so a
+ * character the set does not cover is over-charged rather than let through
+ * cheap, and the guard keeps erring towards rejecting a row it could have
+ * held.
+ */
 const WIDEST_PX = 16;
 
 /**

--- a/src/utils/washFit.ts
+++ b/src/utils/washFit.ts
@@ -37,7 +37,7 @@
  * Advance width, in px, of one character at the binding condition: 600 weight,
  * 30px, Georgia, -0.015em tracking.
  *
- * Georgia and not Fraunces because Fraunces loads with `display=swap`, so Georgia
+ * Georgia and not Literata because Literata loads with `display=swap`, so Georgia
  * — the next family in the display stack — is what paints the phrase until the
  * webfont arrives, and it is the wider of the two. 30px because that is the clamp
  * floor, which is what applies at 320px.
@@ -49,6 +49,16 @@
  * SPEED", "Works Everywhere" and "system", the sum matched the rendered
  * getBoundingClientRect().width to 0.0px every time — this face applies no
  * kerning pairs at this size.
+ *
+ * Georgia stayed the wider of the two across the face swap, confirmed by
+ * rendering those same five phrases in Literata at the binding condition on
+ * 2026-08-15: Literata draws "knows the hour" at 225.1px against the 240 charged
+ * here, "ZERO OVERHEAD" at 258.7 against 291, "Works Everywhere" at 273.4
+ * against 296, "MADE FOR SPEED" at 262.0 against 296, and "system" at 100.1
+ * against 107. So the charges below run roughly 6 to 12 per cent over what
+ * Literata actually draws, and a phrase this file admits still fits once the
+ * webfont lands. The numbers stay as they are: they are Georgia's, and Georgia
+ * is what a reader sees first.
  */
 const ADVANCE_GROUPS: ReadonlyArray<readonly [string, number]> = [
   [" '’", 8], ['.,lj', 10], ['i:;!-', 11], ['ft', 12], ['I()', 13],

--- a/tailwind.config.mjs
+++ b/tailwind.config.mjs
@@ -101,8 +101,9 @@ export default {
                 'on-accent': 'var(--on-accent)'
             },
             fontFamily: {
-                display: ['Fraunces', 'Georgia', '"Times New Roman"', 'serif'],
-                sans: ['Inter', 'system-ui', '-apple-system', '"Segoe UI"', 'sans-serif']
+                display: ['Literata', 'Harmattan', 'Georgia', '"Times New Roman"', 'serif'],
+                sans: ['Readex Pro', 'system-ui', '-apple-system', '"Segoe UI"', 'sans-serif'],
+                mono: ['"JetBrains Mono"', 'ui-monospace', '"SF Mono"', 'Menlo', 'Consolas', 'monospace']
             },
             borderRadius: {
                 chip: '9px',


### PR DESCRIPTION
Brings the site into conformance with the Joe Inz Design System v1.1.0. This is the deferred site-adjustment pass from the showcase page work.

## What changes

- **Typefaces** — retires Fraunces and Inter, adopts Literata + Readex Pro + JetBrains Mono. Mono ligatures disabled per the foundation.
- **State palette** — adds the six-state system, `--focus-ring`, and the published `prefers-contrast: more` block. The four focus indicators now use the focus token instead of accent/caramel.
- **Button contrast** — accent fills take `--choc-ink` (4.59:1) instead of `--on-accent` (3.07:1, which the system marks legacy/AA-LARGE). A 15px semibold label is not large text.
- **Reduced motion** — the blanket clamp killed hover/focus feedback the motion law requires to survive. Feedback now rides `--dur-feedback`; the button press nudge moved off the state duration in the same change, since fixing either alone creates a new violation.
- **Code surfaces** — code fences follow the page theme (they rendered GitHub's dark theme in both modes), and sit on the published `--code-bg`. Plus inline-code background, terminal line-height, dark mono separator, and code selection tint.
- **Type sizes** — converges ~25 near-duplicate sizes onto 11. The hero, section headings and display tier keep their scale; only article `h2` moves (34 → 31). The visible payoff is the about page, where two card lists titled at 27px and 24px now match.

## Verification

No test framework, so `npm run check:build` plus browser assertions on computed styles:

- Reduced motion verified under emulation: `.btn` drops `transform` while keeping colour and filter; the arrow glyph's movement is suppressed; the theme cross-fade survives.
- `navFit.ts` re-measured against Readex Pro and its guard re-proven by forcing a build failure on an over-long label. Real row: 428.5px of 480.
- `washFit.ts` confirmed still conservative — Literata comes in 6-12% under its charged widths.
- Built-CSS selector diff: net +6, all accounted for, no leaked utility rules.
- No Fraunces or Inter requested or loaded on any page, confirmed by network capture on the built output.
- Showcase page unchanged: italic display advance identical to production.

## Notes

- Fence syntax colours are still `github-light`/`github-dark`. A theme built on the system's own `--dev-*` roles is a follow-up; this PR fixes the mode-switching bug and the background.
- Two pre-existing responsive overflows (a blog table at 320px, the `/posts` tag row at 768px) widen slightly because Readex Pro is a wider face. Both are present on production today; out of scope here.
- `package-lock.json` version was stale at 1.5.0 and is synced to 1.7.0.
